### PR TITLE
Add an S3 key name specific encoder to the S3 loader to allow special characters in filenames 

### DIFF
--- a/store/s3store/helpers.go
+++ b/store/s3store/helpers.go
@@ -17,15 +17,10 @@ func Zip(a1, a2 []string) []string {
 func S3Encoder(str string) string {
 	array1 := []string{
 		"+",
-		"!",
 		"\"",
 		"#",
 		"$",
 		"&",
-		"'",
-		"(",
-		")",
-		"*",
 		",",
 		":",
 		";",
@@ -35,15 +30,10 @@ func S3Encoder(str string) string {
 	}
 	array2 := []string{
 		"%2B",
-		"%21",
 		"%22",
 		"%23",
 		"%24",
 		"%26",
-		"%27",
-		"%28",
-		"%29",
-		"%2A",
 		"%2C",
 		"%3A",
 		"%3B",

--- a/store/s3store/helpers.go
+++ b/store/s3store/helpers.go
@@ -1,0 +1,55 @@
+package s3store
+
+import (
+	"strings"
+)
+
+func Zip(a1, a2 []string) []string {
+	r := make([]string, 2*len(a1))
+	for i, e := range a1 {
+		r[i*2] = e
+		r[i*2+1] = a2[i]
+	}
+	return r
+}
+
+func S3Encoder(str string) string {
+	array1 := []string { 
+		"+",
+		"!",
+		"\"",
+		"#",
+		"$",
+		"&",
+		"'",
+		"(",
+		")",
+		"*",
+		",",
+		":",
+		";",
+		"=",
+		"?",
+		"@",
+	}
+	array2 := []string { 
+		"%2B",
+		"%21",
+		"%22",
+		"%23",
+		"%24",
+		"%26",
+		"%27",
+		"%28",
+		"%29",
+		"%2A",
+		"%2C",
+		"%3A",
+		"%3B",
+		"%3D",
+		"%3F",
+		"%40",
+	}
+	str = strings.NewReplacer(Zip(array1, array2)...).Replace(str)
+	return str
+}

--- a/store/s3store/helpers.go
+++ b/store/s3store/helpers.go
@@ -1,6 +1,7 @@
 package s3store
 
 import (
+	"path"
 	"strings"
 )
 
@@ -14,7 +15,7 @@ func Zip(a1, a2 []string) []string {
 }
 
 func S3Encoder(str string) string {
-	array1 := []string { 
+	array1 := []string{
 		"+",
 		"!",
 		"\"",
@@ -32,7 +33,7 @@ func S3Encoder(str string) string {
 		"?",
 		"@",
 	}
-	array2 := []string { 
+	array2 := []string{
 		"%2B",
 		"%21",
 		"%22",
@@ -52,4 +53,16 @@ func S3Encoder(str string) string {
 	}
 	str = strings.NewReplacer(Zip(array1, array2)...).Replace(str)
 	return str
+}
+
+// Normalize imagor path to be file path friendly
+func S3Normalize(image string) string {
+	var escaped []string
+	image = path.Clean(image)
+	image = strings.Trim(image, "/")
+	parts := strings.Split(image, "/")
+	for _, part := range parts {
+		escaped = append(escaped, S3Encoder(part))
+	}
+	return strings.Join(escaped, "/")
 }

--- a/store/s3store/s3store.go
+++ b/store/s3store/s3store.go
@@ -48,7 +48,7 @@ func New(sess *session.Session, bucket string, options ...Option) *S3Store {
 }
 
 func (s *S3Store) Path(image string) (string, bool) {
-	image = "/" + S3Encoder(image)
+	image = "/" + S3Normalize(image)
 	if !strings.HasPrefix(image, s.PathPrefix) {
 		return "", false
 	}

--- a/store/s3store/s3store.go
+++ b/store/s3store/s3store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/cshum/imagor"
-	"github.com/cshum/imagor/imagorpath"
 	"io"
 	"mime"
 	"net/http"
@@ -49,7 +48,7 @@ func New(sess *session.Session, bucket string, options ...Option) *S3Store {
 }
 
 func (s *S3Store) Path(image string) (string, bool) {
-	image = "/" + imagorpath.Normalize(image)
+	image = "/" + S3Encoder(image)
 	if !strings.HasPrefix(image, s.PathPrefix) {
 		return "", false
 	}


### PR DESCRIPTION
This pull request is to fix an issue mentioned here: #12. Currently, S3 key names are encoded using url encoding when using the S3 loader. The problem is that there could be filenames that use special characters which are allowed in S3 which will not be found because of the encoding.

This pull request removes the url encoder and adds an S3 specific encoder that only encodes special characters that are not allowed according to Amazon S3: [https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html). This was tested locally and works for the regular use cases and fixes the issue.

> Characters that might require special handling
The following characters in a key name might require additional code handling and likely need to be URL encoded or referenced as HEX. Some of these are non-printable characters that your browser might not handle, which also requires special handling:
```
Ampersand ("&")

Dollar ("$")

ASCII character ranges 00–1F hex (0–31 decimal) and 7F (127 decimal)

'At' symbol ("@")

Equals ("=")

Semicolon (";")

Colon (":")

Plus ("+")

Space – Significant sequences of spaces might be lost in some uses (especially multiple spaces)

Comma (",")

Question mark ("?")
```