### PR TITLE
Add support for avif and auto avif

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 ARG GOLANG_VERSION=1.17
-FROM golang:${GOLANG_VERSION}-buster as builder
+FROM golang:${GOLANG_VERSION}-bullseye as builder
 
 ARG VIPS_VERSION=8.12.2
+
+# libaom3 is in Debian bullseye-backports 
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list
 
 # Installs libvips + required libraries
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -12,7 +15,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
   gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg62-turbo-dev libpng-dev \
   libwebp-dev libtiff5-dev libgif-dev libexif-dev libxml2-dev libpoppler-glib-dev \
   swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio-dev \
-  libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev libimagequant-dev libheif-dev && \
+  libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev libimagequant-dev libaom-dev/bullseye-backports libheif-dev && \
   cd /tmp && \
   curl -fsSLO https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz && \
   tar zvxf vips-${VIPS_VERSION}.tar.gz && \
@@ -42,19 +45,20 @@ COPY . .
 RUN go test ./...
 RUN go build -o ${GOPATH}/bin/imagor ./cmd/imagor/main.go
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /etc/apt/sources.list.d/backports.list /etc/apt/sources.list.d/backports.list
 
 # Install runtime dependencies
 RUN DEBIAN_FRONTEND=noninteractive \
   apt-get update && \
   apt-get install --no-install-recommends -y \
-  procps libglib2.0-0 libjpeg62-turbo libpng16-16 libopenexr23 \
+  procps libglib2.0-0 libjpeg62-turbo libpng16-16 libopenexr25 \
   libwebp6 libwebpmux3 libwebpdemux2 libtiff5 libgif7 libexif12 libxml2 libpoppler-glib8 \
-  libmagickwand-6.q16-6 libpango1.0-0 libmatio4 libopenslide0 \
-  libgsf-1-114 fftw3 liborc-0.4-0 librsvg2-2 libcfitsio7 libimagequant0 libheif1 && \
+  libmagickwand-6.q16-6 libpango1.0-0 libmatio11 libopenslide0 \
+  libgsf-1-114 fftw3 liborc-0.4-0 librsvg2-2 libcfitsio9 libimagequant0 libaom3 libheif1 && \
   apt-get autoremove -y && \
   apt-get autoclean && \
   apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Imagor supports the following filters:
     - If color is "blur" - missing parts are filled with blurred original image.
     - If color is "auto" - the top left image pixel will be chosen as the filling color
 - `format(format)` specifies the output format of the image
-  - `format` accepts jpeg, png, gif, webp, jp2, tiff
+  - `format` accepts jpeg, png, gif, webp, jp2, tiff, avif
 - `frames(n[, delay])` set the number of frames to repeat for animation with gif or webp. Otherwise, stack all the frames vertically
   - `n` number of frames to repeat
   - `delay` frames delay in milliseconds, default 100
@@ -311,6 +311,8 @@ Usage of imagor:
         Unsafe Imagor that does not require URL signature. Prone to URL tampering
   -imagor-auto-webp
         Output WebP format automatically if browser supports
+  -imagor-auto-avif
+        Output Avif format automatically if browser supports
   -imagor-cache-header-ttl duration
         Imagor HTTP cache header ttl for successful image response. Set -1 for no-cache (default 24h0m0s)
   -imagor-request-timeout duration

--- a/cmd/imagor/main.go
+++ b/cmd/imagor/main.go
@@ -48,6 +48,8 @@ func main() {
 			"Unsafe Imagor that does not require URL signature. Prone to URL tampering")
 		imagorAutoWebP = fs.Bool("imagor-auto-webp", false,
 			"Output WebP format automatically if browser supports")
+		imagorAutoAvif = fs.Bool("imagor-auto-avif", false,
+			"Output Avif format automatically if browser supports")
 		imagorRequestTimeout = fs.Duration("imagor-request-timeout",
 			time.Second*30, "Timeout for performing Imagor request")
 		imagorLoadTimeout = fs.Duration("imagor-load-timeout",
@@ -445,6 +447,7 @@ func main() {
 			imagor.WithProcessConcurrency(*imagorProcessConcurrency),
 			imagor.WithCacheHeaderTTL(*imagorCacheHeaderTTL),
 			imagor.WithAutoWebP(*imagorAutoWebP),
+			imagor.WithAutoAvif(*imagorAutoAvif),
 			imagor.WithUnsafe(*imagorUnsafe),
 			imagor.WithLogger(logger),
 			imagor.WithDebug(*debug),

--- a/imagor.go
+++ b/imagor.go
@@ -63,6 +63,7 @@ type Imagor struct {
 	CacheHeaderTTL     time.Duration
 	ProcessConcurrency int64
 	AutoWebP           bool
+	AutoAvif           bool
 	Logger             *zap.Logger
 	Debug              bool
 
@@ -198,16 +199,23 @@ func (app *Imagor) Do(r *http.Request, p imagorpath.Params) (blob *Blob, err err
 		}
 		return
 	}
-	// auto WebP
-	if app.AutoWebP {
-		if accept := r.Header.Get("Accept"); strings.Contains(accept, "image/webp") {
-			var hasFormat bool
-			for _, f := range p.Filters {
-				if f.Name == "format" {
-					hasFormat = true
-				}
+	// auto WebP / Avif
+	if app.AutoWebP || app.AutoAvif {
+		var hasFormat bool
+		for _, f := range p.Filters {
+			if f.Name == "format" {
+				hasFormat = true
 			}
-			if !hasFormat {
+		}
+		if !hasFormat {
+			accept := r.Header.Get("Accept")
+			if strings.Contains(accept, "image/avif") && app.AutoAvif {
+				p.Filters = append(p.Filters, imagorpath.Filter{
+					Name: "format",
+					Args: "avif",
+				})
+				p.Path = imagorpath.GeneratePath(p)
+			} else if strings.Contains(accept, "image/webp") && app.AutoWebP {
 				p.Filters = append(p.Filters, imagorpath.Filter{
 					Name: "format",
 					Args: "webp",

--- a/imagor_test.go
+++ b/imagor_test.go
@@ -495,6 +495,73 @@ func TestAutoWebP(t *testing.T) {
 	})
 }
 
+func TestAutoAvif(t *testing.T) {
+	factory := func(isAuto bool) *Imagor {
+		return New(
+			WithDebug(true),
+			WithUnsafe(true),
+			WithAutoAvif(isAuto),
+			WithLoaders(loaderFunc(func(r *http.Request, image string) (*Blob, error) {
+				return NewBlobBytes([]byte("foo")), nil
+			})),
+			WithProcessors(processorFunc(func(ctx context.Context, blob *Blob, p imagorpath.Params, load LoadFunc) (*Blob, error) {
+				return NewBlobBytes([]byte(p.Path)), nil
+			})),
+			WithDebug(true))
+	}
+
+	t.Run("supported auto img tag not enabled", func(t *testing.T) {
+		app := factory(false)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(
+			http.MethodGet, "https://example.com/unsafe/abc.png", nil)
+		r.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+		app.ServeHTTP(w, r)
+		assert.Equal(t, 200, w.Code)
+		assert.Equal(t, w.Body.String(), "abc.png")
+	})
+	t.Run("supported auto img tag", func(t *testing.T) {
+		app := factory(true)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(
+			http.MethodGet, "https://example.com/unsafe/abc.png", nil)
+		r.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+		app.ServeHTTP(w, r)
+		assert.Equal(t, 200, w.Code)
+		assert.Equal(t, w.Body.String(), "filters:format(avif)/abc.png")
+	})
+	t.Run("supported not image tag auto", func(t *testing.T) {
+		app := factory(true)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(
+			http.MethodGet, "https://example.com/unsafe/abc.png", nil)
+		r.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*")
+		app.ServeHTTP(w, r)
+		assert.Equal(t, 200, w.Code)
+		assert.Equal(t, w.Body.String(), "filters:format(avif)/abc.png")
+	})
+	t.Run("no supported no auto", func(t *testing.T) {
+		app := factory(true)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(
+			http.MethodGet, "https://example.com/unsafe/abc.png", nil)
+		r.Header.Set("Accept", "image/apng,image/svg+xml,image/*,*/*;q=0.8")
+		app.ServeHTTP(w, r)
+		assert.Equal(t, 200, w.Code)
+		assert.Equal(t, w.Body.String(), "abc.png")
+	})
+	t.Run("explicit format no auto", func(t *testing.T) {
+		app := factory(true)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(
+			http.MethodGet, "https://example.com/unsafe/filters:format(jpg)/abc.png", nil)
+		r.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+		app.ServeHTTP(w, r)
+		assert.Equal(t, 200, w.Code)
+		assert.Equal(t, w.Body.String(), "filters:format(jpg)/abc.png")
+	})
+}
+
 func TestWithLoadTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.String(), "sleep") {

--- a/option.go
+++ b/option.go
@@ -107,6 +107,12 @@ func WithAutoWebP(enable bool) Option {
 	}
 }
 
+func WithAutoAvif(enable bool) Option {
+	return func(o *Imagor) {
+		o.AutoAvif = enable
+	}
+}
+
 func WithSecret(secret string) Option {
 	return func(o *Imagor) {
 		o.Secret = secret

--- a/processor/vipsprocessor/vips.go
+++ b/processor/vipsprocessor/vips.go
@@ -304,10 +304,18 @@ func (v *VipsProcessor) Process(
 func getMeta(meta *vips.ImageMetadata) *imagor.Meta {
 	format, ok := vips.ImageTypes[meta.Format]
 	contentType, ok2 := imageMimeTypeMap[format]
+
+	// govips returns "image/heif" for avif image content types
+	if meta.Format == vips.ImageTypeAVIF {
+		format = "avif"
+		contentType = "image/avif"
+	}
+
 	if !ok || !ok2 {
 		format = "jpeg"
 		contentType = "image/jpeg"
 	}
+
 	return &imagor.Meta{
 		Format:      format,
 		ContentType: contentType,


### PR DESCRIPTION
This PR adds build support for avif images as well as an auto avif feature. I updated the Dockerfile to use debian bullseye instead of buster because package manager support for libaom/libheif is much better.

Unfortunately, avif encoding is very slow and as far as I can tell is resulting in larger file sizes than webp and even jpg:

```
➜  imagor git:(master) ✗ curl -s -I -X GET http://localhost:8000/unsafe/fit-in/1920x2879/filters:format\(webp\)/images.unsplash.com/photo-1652744922302-faf8a02bc23e | grep Content-Length
Content-Length: 161802

➜  imagor git:(master) ✗ curl -s -I -X GET http://localhost:8000/unsafe/fit-in/1920x2879/filters:format\(jpg\)/images.unsplash.com/photo-1652744922302-faf8a02bc23e | grep Content-Length
Content-Length: 362441

➜  imagor git:(master) ✗ curl -s -I -X GET http://localhost:8000/unsafe/fit-in/1920x2879/filters:format\(avif\)/images.unsplash.com/photo-1652744922302-faf8a02bc23e | grep Content-Length
Content-Length: 1591130

➜  imagor git:(master) ✗ curl -s -I -X GET http://localhost:8000/unsafe/fit-in/1920x2879/filters:format\(avif\):quality\(50\)/images.unsplash.com/photo-1652744922302-faf8a02bc23e | grep Content-Length
Content-Length: 430705
```