### PR TITLE
feat(imagor): return 404 in case the host is not found in the http loader

### DIFF
--- a/loader/httploader/httploader.go
+++ b/loader/httploader/httploader.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -113,7 +112,7 @@ func (h *HTTPLoader) Get(r *http.Request, image string) (*imagor.Blob, error) {
 	return imagor.NewBlob(func() (io.ReadCloser, int64, error) {
 		resp, err := client.Do(req)
 		if err != nil {
-			if b, _ := regexp.MatchString("(no such host)$", err.Error()); b {
+			if strings.Contains(err.Error(), "no such host") {
 				err = imagor.ErrNotFound
 			}
 

--- a/loader/httploader/httploader.go
+++ b/loader/httploader/httploader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -112,6 +113,10 @@ func (h *HTTPLoader) Get(r *http.Request, image string) (*imagor.Blob, error) {
 	return imagor.NewBlob(func() (io.ReadCloser, int64, error) {
 		resp, err := client.Do(req)
 		if err != nil {
+			if b, _ := regexp.MatchString("(no such host)$", err.Error()); b {
+				err = imagor.ErrNotFound
+			}
+
 			return nil, 0, err
 		}
 		body := resp.Body

--- a/loader/httploader/httploader_test.go
+++ b/loader/httploader/httploader_test.go
@@ -505,3 +505,37 @@ func TestWithGzip(t *testing.T) {
 		},
 	})
 }
+
+func TestWithHostDomains(t *testing.T) {
+	doTests(t, New(
+		WithTransport(testTransport{
+			"https://foo.bar/baz":      "baz",
+			"foo/bar":                  "bar",
+			"http://10.0.0.1:8080/foo": "foo",
+			"http://baz/qux":           "qux",
+		}),
+	), []test{
+		{
+			name:   "valid host",
+			target: "https://foo.bar/baz",
+			result: "baz",
+		},
+		{
+			name:   "invalid host not found",
+			target: "foo/bar",
+			result: "not found",
+			err:    "imagor: 404 Not Found",
+		},
+		{
+			name:   "valid host",
+			target: "http://10.0.0.1:8080/foo",
+			result: "foo",
+		},
+		{
+			name:   "invalid host not found",
+			target: "http://baz/qux.jpeg",
+			result: "not found",
+			err:    "imagor: 404 Not Found",
+		},
+	})
+}

--- a/loader/httploader/httploader_test.go
+++ b/loader/httploader/httploader_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cshum/imagor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +20,7 @@ func (t testTransport) RoundTrip(r *http.Request) (w *http.Response, err error) 
 	if res, ok := t[r.URL.String()]; ok {
 		w = &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader(res)),
+			Body:       io.NopCloser(strings.NewReader(res)),
 			Header:     map[string][]string{},
 		}
 		w.Header.Set("Content-Type", "image/jpeg")
@@ -28,7 +28,7 @@ func (t testTransport) RoundTrip(r *http.Request) (w *http.Response, err error) 
 	}
 	w = &http.Response{
 		StatusCode: http.StatusNotFound,
-		Body:       ioutil.NopCloser(strings.NewReader("not found")),
+		Body:       io.NopCloser(strings.NewReader("not found")),
 	}
 	return
 }
@@ -205,7 +205,7 @@ func TestWithUserAgent(t *testing.T) {
 			res := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				Body:       io.NopCloser(strings.NewReader("ok")),
 			}
 			res.Header.Set("Content-Type", "image/jpeg")
 			return res, nil
@@ -229,7 +229,7 @@ func TestWithForwardHeaders(t *testing.T) {
 			res := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				Body:       io.NopCloser(strings.NewReader("ok")),
 			}
 			res.Header.Set("Content-Type", "image/jpeg")
 			return res, nil
@@ -254,7 +254,7 @@ func TestWithForwardHeadersOverrideUserAgent(t *testing.T) {
 			res := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				Body:       io.NopCloser(strings.NewReader("ok")),
 			}
 			res.Header.Set("Content-Type", "image/jpeg")
 			return res, nil
@@ -279,7 +279,7 @@ func TestWithForwardClientHeaders(t *testing.T) {
 			res := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				Body:       io.NopCloser(strings.NewReader("ok")),
 			}
 			res.Header.Set("Content-Type", "image/jpeg")
 			return res, nil
@@ -304,7 +304,7 @@ func TestWithOverrideHeaders(t *testing.T) {
 			res := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				Body:       io.NopCloser(strings.NewReader("ok")),
 			}
 			res.Header.Set("Content-Type", "image/jpeg")
 			return res, nil
@@ -329,7 +329,7 @@ func TestWithOverrideForwardHeaders(t *testing.T) {
 			res := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				Body:       io.NopCloser(strings.NewReader("ok")),
 			}
 			res.Header.Set("Content-Type", "image/jpeg")
 			return res, nil
@@ -448,7 +448,7 @@ func TestWithAccept(t *testing.T) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(strings.NewReader("ok")),
+				Body:       io.NopCloser(strings.NewReader("ok")),
 			}
 			resp.Header.Set("Content-Type", strings.TrimPrefix(r.URL.Path, "/"))
 			return resp, nil
@@ -491,7 +491,7 @@ func TestWithGzip(t *testing.T) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     map[string][]string{},
-				Body:       ioutil.NopCloser(bytes.NewReader(gzipBytes([]byte("ok")))),
+				Body:       io.NopCloser(bytes.NewReader(gzipBytes([]byte("ok")))),
 			}
 			resp.Header.Set("Content-Encoding", "gzip")
 			resp.Header.Set("Content-Type", "image/jpeg")


### PR DESCRIPTION
Issue: #213 

The HTTP loader is currently appended to the other Loaders. Doing so replaces the errors from the other loaders, so one solution to avoid invalid results of returning 500 is to check if the domain is valid in the HTTP Loader. The URL scheme is added to the image if it does not exist, making almost everything a "valid" domain. Ideally, it should return 404.

I thought of 3 solutions:
1. Making the HTTP loader run before the other loaders (not accepted)
2. Sticking with the first error ignoring what is coming next
3. Simple validation of the result of the HTTP call (contained in this PR)

I believe the second solution would cause even more issues, so I chose the third option, as we can work with multiple loaders.

Please let me know if that is valid or if you have something else in your mind.
 
