### PR TITLE
feat(metrics): Instrument http server

### DIFF
--- a/metrics/prometheusmetrics/prometheus.go
+++ b/metrics/prometheusmetrics/prometheus.go
@@ -2,7 +2,6 @@ package prometheusmetrics
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,8 +51,7 @@ func New(options ...Option) *PrometheusMetrics {
 
 // Startup prometheus metrics server
 func (s *PrometheusMetrics) Startup(_ context.Context) error {
-	err := prometheus.Register(httpRequestDuration)
-	if err != nil && !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+	if err := prometheus.Register(httpRequestDuration); err != nil {
 		return err
 	}
 

--- a/metrics/prometheusmetrics/prometheus.go
+++ b/metrics/prometheusmetrics/prometheus.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"net/http"
-
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
+	"net/http"
 )
 
 var (

--- a/metrics/prometheusmetrics/prometheus.go
+++ b/metrics/prometheusmetrics/prometheus.go
@@ -3,10 +3,11 @@ package prometheusmetrics
 import (
 	"context"
 	"errors"
+	"net/http"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
-	"net/http"
 )
 
 var (

--- a/metrics/prometheusmetrics/prometheus_test.go
+++ b/metrics/prometheusmetrics/prometheus_test.go
@@ -1,6 +1,8 @@
 package prometheusmetrics
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,5 +27,9 @@ func TestWithOption(t *testing.T) {
 		assert.Equal(t, "/myprom", v.Path)
 		assert.Equal(t, "domain.example.com:1111", v.Addr)
 		assert.Equal(t, &l, &v.Logger)
+		w := httptest.NewRecorder()
+		v.Handler.ServeHTTP(w, httptest.NewRequest(
+			http.MethodGet, "https://example.com/", nil))
+		assert.Equal(t, http.StatusPermanentRedirect, w.Code)
 	})
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -3,17 +3,36 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
 )
 
 type errResp struct {
 	Message string `json:"message,omitempty"`
 	Code    int    `json:"status,omitempty"`
+}
+
+var (
+	httpRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "http_request_duration_seconds",
+			Help: "A histogram of latencies for requests",
+		},
+		[]string{"code", "method"},
+	)
+)
+
+// init registers server metrics with the Prometheus registry
+// It is (generally) idempotent by ignoring AlreadyRegisteredError(s), but should probably only be called once
+func init() {
+	prometheus.MustRegister(httpRequestDuration)
 }
 
 func handleOk(w http.ResponseWriter, r *http.Request) {
@@ -39,6 +58,10 @@ func (s *Server) panicHandler(next http.Handler) http.Handler {
 		}()
 		next.ServeHTTP(w, r)
 	})
+}
+
+func (s *Server) durationHandler(next http.Handler) http.Handler {
+	return promhttp.InstrumentHandlerDuration(httpRequestDuration, next)
 }
 
 func pathHandler(

--- a/server/handler.go
+++ b/server/handler.go
@@ -9,30 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 )
 
 type errResp struct {
 	Message string `json:"message,omitempty"`
 	Code    int    `json:"status,omitempty"`
-}
-
-var (
-	httpRequestDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "http_request_duration_seconds",
-			Help: "A histogram of latencies for requests",
-		},
-		[]string{"code", "method"},
-	)
-)
-
-// init registers server metrics with the Prometheus registry
-// It is (generally) idempotent by ignoring AlreadyRegisteredError(s), but should probably only be called once
-func init() {
-	prometheus.MustRegister(httpRequestDuration)
 }
 
 func handleOk(w http.ResponseWriter, r *http.Request) {
@@ -58,10 +40,6 @@ func (s *Server) panicHandler(next http.Handler) http.Handler {
 		}()
 		next.ServeHTTP(w, r)
 	})
-}
-
-func (s *Server) durationHandler(next http.Handler) http.Handler {
-	return promhttp.InstrumentHandlerDuration(httpRequestDuration, next)
 }
 
 func pathHandler(

--- a/server/server.go
+++ b/server/server.go
@@ -25,9 +25,15 @@ type Service interface {
 
 // Metrics represents metrics Startup and Shutdown lifecycle and Handle middleware
 type Metrics interface {
-	Startup(ctx context.Context) error
-	Shutdown(ctx context.Context) error
+
+	// Handle HTTP middleware metrics handler
 	Handle(next http.Handler) http.Handler
+
+	// Startup controls metrics startup
+	Startup(ctx context.Context) error
+
+	// Shutdown controls metrics shutdown
+	Shutdown(ctx context.Context) error
 }
 
 // Server wraps the Service with additional http and app lifecycle handling


### PR DESCRIPTION
* Add Histogram: http_request_duration_seconds
* Instrument http server between app and handlers like /heathcheck to avoid observing metrics about /healthcheck
* Example metrics returned after a few requests (that happened to be 404):
```
# HELP http_request_duration_seconds A histogram of latencies for requests
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{code="404",method="get",le="0.005"} 0
http_request_duration_seconds_bucket{code="404",method="get",le="0.01"} 0
http_request_duration_seconds_bucket{code="404",method="get",le="0.025"} 0
http_request_duration_seconds_bucket{code="404",method="get",le="0.05"} 1
http_request_duration_seconds_bucket{code="404",method="get",le="0.1"} 2
http_request_duration_seconds_bucket{code="404",method="get",le="0.25"} 2
http_request_duration_seconds_bucket{code="404",method="get",le="0.5"} 2
http_request_duration_seconds_bucket{code="404",method="get",le="1"} 2
http_request_duration_seconds_bucket{code="404",method="get",le="2.5"} 2
http_request_duration_seconds_bucket{code="404",method="get",le="5"} 2
http_request_duration_seconds_bucket{code="404",method="get",le="10"} 2
http_request_duration_seconds_bucket{code="404",method="get",le="+Inf"} 2
http_request_duration_seconds_sum{code="404",method="get"} 0.124959676
http_request_duration_seconds_count{code="404",method="get"} 2
```

The `_count` is useful for `rate()`, the `_sum` and `_buckets` are useful for calculating percentiles