### PR TITLE
feat(httploader): add allowed source regexp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,11 +384,19 @@ VIPS_MAX_HEIGHT=5000
 
 #### Allowed Sources and Base URL
 
-Whitelist specific hosts to restrict loading images only from the allowed sources using `HTTP_LOADER_ALLOWED_SOURCES`. Accept csv wth glob pattern e.g.:
+Whitelist specific hosts to restrict loading images only from the allowed sources using `HTTP_LOADER_ALLOWED_SOURCES` or `HTTP_LOADER_ALLOWED_SOURCE_REGEXP`.
 
-```dotenv
-HTTP_LOADER_ALLOWED_SOURCES=*.foobar.com,my.foobar.com,mybucket.s3.amazonaws.com
-```
+- `HTTP_LOADER_ALLOWED_SOURCES` accepts csv wth glob pattern e.g.:
+
+  ```dotenv
+  HTTP_LOADER_ALLOWED_SOURCES=*.foobar.com,my.foobar.com,mybucket.s3.amazonaws.com
+  ```
+
+- `HTTP_LOADER_ALLOWED_SOURCE_REGEXP` accepts a regular expression matching on the full URL e.g.:
+
+  ```dotenv
+  HTTP_LOADER_ALLOWED_SOURCE_REGEXP='^https://raw\.githubusercontent\.com/cshum/imagor/.*'
+  ```
 
 Alternatively, it is possible to set a base URL for loading images strictly from one HTTP source. This also trims down the base URL from image endpoint:
 
@@ -635,6 +643,8 @@ Usage of imagor:
         HTTP Loader maximum allowed size in bytes for loading images if set
   -http-loader-proxy-urls string
         HTTP Loader Proxy URLs. Enable HTTP Loader proxy only if this value present. Accept csv of proxy urls e.g. http://user:pass@host:port,http://user:pass@host:port
+  -http-loader-allowed-source-regexp string
+        HTTP Loader allowed hosts regexp to load images from if set. Combines as OR with allowed host glob pattern sources.
   -http-loader-proxy-allowed-sources string
         HTTP Loader Proxy allowed hosts that enable proxy transport, if proxy URLs are set. Accept csv wth glob pattern e.g. *.google.com,*.github.com.
   -http-loader-default-scheme string

--- a/config/httpconfig.go
+++ b/config/httpconfig.go
@@ -18,6 +18,8 @@ func withHTTPLoader(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Opti
 			"Forward browser client request headers to HTTP Loader request")
 		httpLoaderForwardAllHeaders = fs.Bool("http-loader-forward-all-headers", false,
 			"Deprecated in flavour of -http-loader-forward-client-headers")
+		httpLoaderAllowedSourceRegexp = fs.String("http-loader-allowed-source-regexp", "",
+			"HTTP Loader allowed hosts regexp to load images from if set. Combines as OR with allowed host glob pattern sources.")
 		httpLoaderAllowedSources = fs.String("http-loader-allowed-sources", "",
 			"HTTP Loader allowed hosts whitelist to load images from if set. Accept csv wth glob pattern e.g. *.google.com,*.github.com.")
 		httpLoaderMaxAllowedSize = fs.Int("http-loader-max-allowed-size", 0,
@@ -57,6 +59,7 @@ func withHTTPLoader(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Opti
 					httploader.WithAccept(*httpLoaderAccept),
 					httploader.WithForwardHeaders(*httpLoaderForwardHeaders),
 					httploader.WithAllowedSources(*httpLoaderAllowedSources),
+					httploader.WithAllowedSourceRegexps(*httpLoaderAllowedSourceRegexp),
 					httploader.WithMaxAllowedSize(*httpLoaderMaxAllowedSize),
 					httploader.WithInsecureSkipVerifyTransport(*httpLoaderInsecureSkipVerifyTransport),
 					httploader.WithDefaultScheme(*httpLoaderDefaultScheme),

--- a/loader/httploader/httploader_test.go
+++ b/loader/httploader/httploader_test.go
@@ -133,6 +133,51 @@ func TestWithAllowedSources(t *testing.T) {
 	})
 }
 
+func TestWithAllowedSourceRegexp(t *testing.T) {
+	doTests(t, New(
+		WithTransport(testTransport{
+			"https://goo.org/image1.png":   "goo_image1",
+			"https://foo.com/dogs/dog.jpg": "dog",
+		}),
+		WithAllowedSourceRegexps(
+			`^https://(foo|bar)\.com/dogs/.*\.jpg$`,
+			`^https://goo\.org/.*`,
+		),
+	), []test{
+		{
+			name:   "allowed source",
+			target: "https://goo.org/image1.png",
+			result: "goo_image1",
+		},
+		{
+			name:   "allowed source",
+			target: "https://foo.com/dogs/dog.jpg",
+			result: "dog",
+		},
+		{
+			name:   "allowed not found",
+			target: "https://goo.org/image2.png",
+			result: "not found",
+			err:    "imagor: 404 Not Found",
+		},
+		{
+			name:   "not allowed source",
+			target: "https://goo2.org/https://goo.org/image.png",
+			err:    "imagor: 400 invalid",
+		},
+		{
+			name:   "not allowed source",
+			target: "https://foo.com/dogs/../cats/cat.jpg",
+			err:    "imagor: 400 invalid",
+		},
+		{
+			name:   "not allowed source",
+			target: "https://foo.com/dogs/dog.jpg?size=small",
+			err:    "imagor: 400 invalid",
+		},
+	})
+}
+
 func TestWithAllowedSourcesRedirect(t *testing.T) {
 
 	t.Run("Forbidden redirect", func(t *testing.T) {

--- a/loader/httploader/option.go
+++ b/loader/httploader/option.go
@@ -84,8 +84,19 @@ func WithAllowedSources(hosts ...string) Option {
 			for _, host := range splits {
 				host = strings.TrimSpace(host)
 				if len(host) > 0 {
-					h.AllowedSources = append(h.AllowedSources, host)
+					h.AllowedSources = append(h.AllowedSources,
+						NewHostPatternAllowedSource(host))
 				}
+			}
+		}
+	}
+}
+
+func WithAllowedSourceRegexps(patterns ...string) Option {
+	return func(h *HTTPLoader) {
+		for _, pat := range patterns {
+			if as, err := NewRegexpAllowedSource(pat); pat != "" && err == nil {
+				h.AllowedSources = append(h.AllowedSources, as)
 			}
 		}
 	}

--- a/loader/httploader/util.go
+++ b/loader/httploader/util.go
@@ -10,7 +10,7 @@ import (
 
 func randomProxyFunc(proxyURLs, hosts string) func(*http.Request) (*url.URL, error) {
 	var urls []*url.URL
-	var allowedSources []string
+	var allowedSources []AllowedSource
 	for _, split := range strings.Split(proxyURLs, ",") {
 		if u, err := url.Parse(strings.TrimSpace(split)); err == nil {
 			urls = append(urls, u)
@@ -20,7 +20,7 @@ func randomProxyFunc(proxyURLs, hosts string) func(*http.Request) (*url.URL, err
 	for _, host := range strings.Split(hosts, ",") {
 		host = strings.TrimSpace(host)
 		if len(host) > 0 {
-			allowedSources = append(allowedSources, host)
+			allowedSources = append(allowedSources, NewHostPatternAllowedSource(host))
 		}
 	}
 	return func(r *http.Request) (u *url.URL, err error) {
@@ -35,12 +35,12 @@ func randomProxyFunc(proxyURLs, hosts string) func(*http.Request) (*url.URL, err
 	}
 }
 
-func isURLAllowed(u *url.URL, allowedSources []string) bool {
+func isURLAllowed(u *url.URL, allowedSources []AllowedSource) bool {
 	if len(allowedSources) == 0 {
 		return true
 	}
 	for _, source := range allowedSources {
-		if matched, e := path.Match(source, u.Host); matched && e == nil {
+		if source.Match(u) {
 			return true
 		}
 	}


### PR DESCRIPTION
This commit introduces a new option for the httploader that allows to specify a regexp that will be used to filter the sources that are allowed to be loaded.

It is useful for whitelisting paths that can't be covered by the host based filtering, for example when wanting to load from multiple GCS buckets by URL, and GCS bucket names are part of the path in the URL unlike S3 bucket names that are part of the host name.