### PR TITLE
Set content-type to image/svg+xml for SVG files

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func doTestBlobReaders(t *testing.T, b *Blob, buf []byte) {
@@ -124,6 +125,13 @@ func TestBlobTypes(t *testing.T) {
 			contentType: "image/bmp",
 			extension:   ".bmp",
 			bytesType:   BlobTypeBMP,
+		},
+		{
+			name:        "svg",
+			path:        "test.svg",
+			contentType: "image/svg+xml",
+			extension:   ".svg",
+			bytesType:   BlobTypeSVG,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Before this change:

```
❯ curl --head 'localhost:8000/unsafe/filters:raw()/https://some-svg-file.svg'
HTTP/1.1 200 OK
Cache-Control: public, s-maxage=604800, max-age=604800, no-transform, stale-while-revalidate=86400
Content-Disposition: inline
Content-Length: 1463870
Content-Security-Policy: script-src 'none'
Content-Type: text/xml; charset=utf-8
Etag: 645c9ea0-16563e
Expires: Thu, 18 May 2023 14:03:03 IST
Last-Modified: Thu, 11 May 2023 13:22:00 GMT
Date: Thu, 11 May 2023 08:33:03 GMT
```

After this change:

```
❯ curl --head 'localhost:8000/unsafe/filters:raw()/https://some-svg-file.svg'
HTTP/1.1 200 OK
Cache-Control: public, s-maxage=604800, max-age=604800, no-transform, stale-while-revalidate=86400
Content-Disposition: inline
Content-Length: 1463870
Content-Security-Policy: script-src 'none'
Content-Type: image/svg+xml
Etag: 645c9ea0-16563e
Expires: Thu, 18 May 2023 14:00:37 IST
Last-Modified: Thu, 11 May 2023 13:22:00 GMT
Date: Thu, 11 May 2023 08:30:37 GMT
```

If the content-type is set to `text/xml`, the image will not be rendered by browser when used inside an img tag. It will be rendered only if the content-type is set to `image/svg+xml`.