### PR TITLE
Add ability to specify dpi when converting PDF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ imagor supports the following filters:
 - `orient(angle)` rotates the image before resizing and cropping, according to the angle value
   - `angle` accepts 0, 90, 180, 270
 - `page(num)` specify page number for PDF, or frame number for animated image, starts from 1
+- `dpi(num)` specify the dpi to render at for PDF and SVG
 - `proportion(percentage)` scales image to the proportion percentage of the image dimension
 - `quality(amount)` changes the overall quality of the image, does nothing for png
   - `amount` 0 to 100, the quality level in %

--- a/vips/filter.go
+++ b/vips/filter.go
@@ -48,13 +48,13 @@ func (v *Processor) watermark(ctx context.Context, img *Image, load imagor.LoadF
 			h = img.PageHeight() * h / 100
 		}
 		if overlay, err = v.NewThumbnail(
-			ctx, blob, w, h, InterestingNone, SizeDown, n, 1, nil,
+			ctx, blob, w, h, InterestingNone, SizeDown, n, 1, 0,
 		); err != nil {
 			return
 		}
 	} else {
 		if overlay, err = v.NewThumbnail(
-			ctx, blob, v.MaxWidth, v.MaxHeight, InterestingNone, SizeDown, n, 1, nil,
+			ctx, blob, v.MaxWidth, v.MaxHeight, InterestingNone, SizeDown, n, 1, 0,
 		); err != nil {
 			return
 		}

--- a/vips/filter.go
+++ b/vips/filter.go
@@ -3,14 +3,15 @@ package vips
 import (
 	"context"
 	"fmt"
-	"github.com/cshum/imagor"
-	"github.com/cshum/imagor/imagorpath"
-	"golang.org/x/image/colornames"
 	"image/color"
 	"math"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/cshum/imagor"
+	"github.com/cshum/imagor/imagorpath"
+	"golang.org/x/image/colornames"
 )
 
 func (v *Processor) watermark(ctx context.Context, img *Image, load imagor.LoadFunc, args ...string) (err error) {
@@ -47,13 +48,13 @@ func (v *Processor) watermark(ctx context.Context, img *Image, load imagor.LoadF
 			h = img.PageHeight() * h / 100
 		}
 		if overlay, err = v.NewThumbnail(
-			ctx, blob, w, h, InterestingNone, SizeDown, n, 1,
+			ctx, blob, w, h, InterestingNone, SizeDown, n, 1, nil,
 		); err != nil {
 			return
 		}
 	} else {
 		if overlay, err = v.NewThumbnail(
-			ctx, blob, v.MaxWidth, v.MaxHeight, InterestingNone, SizeDown, n, 1,
+			ctx, blob, v.MaxWidth, v.MaxHeight, InterestingNone, SizeDown, n, 1, nil,
 		); err != nil {
 			return
 		}

--- a/vips/process.go
+++ b/vips/process.go
@@ -2,13 +2,14 @@ package vips
 
 import (
 	"context"
-	"github.com/cshum/imagor"
-	"github.com/cshum/imagor/imagorpath"
-	"go.uber.org/zap"
 	"math"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cshum/imagor"
+	"github.com/cshum/imagor/imagorpath"
+	"go.uber.org/zap"
 )
 
 var imageTypeMap = map[string]ImageType{
@@ -45,6 +46,7 @@ func (v *Processor) Process(
 		maxN                  = v.MaxAnimationFrames
 		maxBytes              int
 		page                  = 1
+		dpi                   *int
 		focalRects            []focal
 		err                   error
 	)
@@ -98,6 +100,11 @@ func (v *Processor) Process(
 				page = n
 			}
 			break
+		case "dpi":
+			if n, _ := strconv.Atoi(p.Args); n > 0 {
+				dpi = &n
+			}
+			break
 		case "orient":
 			if n, _ := strconv.Atoi(p.Args); n > 0 {
 				orient = n
@@ -137,7 +144,7 @@ func (v *Processor) Process(
 					size = SizeBoth
 				}
 				if img, err = v.NewThumbnail(
-					ctx, blob, w, h, InterestingNone, size, maxN, page,
+					ctx, blob, w, h, InterestingNone, size, maxN, page, dpi,
 				); err != nil {
 					return nil, err
 				}
@@ -147,7 +154,7 @@ func (v *Processor) Process(
 			if p.Width > 0 && p.Height > 0 {
 				if img, err = v.NewThumbnail(
 					ctx, blob, p.Width, p.Height,
-					InterestingNone, SizeForce, maxN, page,
+					InterestingNone, SizeForce, maxN, page, dpi,
 				); err != nil {
 					return nil, err
 				}
@@ -175,7 +182,7 @@ func (v *Processor) Process(
 				if thumbnail {
 					if img, err = v.NewThumbnail(
 						ctx, blob, p.Width, p.Height,
-						interest, SizeBoth, maxN, page,
+						interest, SizeBoth, maxN, page, dpi,
 					); err != nil {
 						return nil, err
 					}
@@ -183,7 +190,7 @@ func (v *Processor) Process(
 			} else if p.Width > 0 && p.Height == 0 {
 				if img, err = v.NewThumbnail(
 					ctx, blob, p.Width, v.MaxHeight,
-					InterestingNone, SizeBoth, maxN, page,
+					InterestingNone, SizeBoth, maxN, page, dpi,
 				); err != nil {
 					return nil, err
 				}
@@ -191,7 +198,7 @@ func (v *Processor) Process(
 			} else if p.Height > 0 && p.Width == 0 {
 				if img, err = v.NewThumbnail(
 					ctx, blob, v.MaxWidth, p.Height,
-					InterestingNone, SizeBoth, maxN, page,
+					InterestingNone, SizeBoth, maxN, page, dpi,
 				); err != nil {
 					return nil, err
 				}
@@ -201,13 +208,13 @@ func (v *Processor) Process(
 	}
 	if !thumbnail {
 		if thumbnailNotSupported {
-			if img, err = v.NewImage(ctx, blob, maxN, page); err != nil {
+			if img, err = v.NewImage(ctx, blob, maxN, page, dpi); err != nil {
 				return nil, err
 			}
 		} else {
 			if img, err = v.NewThumbnail(
 				ctx, blob, v.MaxWidth, v.MaxHeight,
-				InterestingNone, SizeDown, maxN, page,
+				InterestingNone, SizeDown, maxN, page, dpi,
 			); err != nil {
 				return nil, err
 			}

--- a/vips/process.go
+++ b/vips/process.go
@@ -46,7 +46,7 @@ func (v *Processor) Process(
 		maxN                  = v.MaxAnimationFrames
 		maxBytes              int
 		page                  = 1
-		dpi                   *int
+		dpi                   = 0
 		focalRects            []focal
 		err                   error
 	)
@@ -102,7 +102,7 @@ func (v *Processor) Process(
 			break
 		case "dpi":
 			if n, _ := strconv.Atoi(p.Args); n > 0 {
-				dpi = &n
+				dpi = n
 			}
 			break
 		case "orient":

--- a/vips/processor.go
+++ b/vips/processor.go
@@ -188,11 +188,11 @@ func newThumbnailFromBlob(
 // NewThumbnail creates new thumbnail with resize and crop from imagor.Blob
 func (v *Processor) NewThumbnail(
 	ctx context.Context, blob *imagor.Blob, width, height int, crop Interesting,
-	size Size, n, page int, dpi *int,
+	size Size, n, page int, dpi int,
 ) (*Image, error) {
 	var params = NewImportParams()
-	if dpi != nil {
-		params.Density.Set(*dpi)
+	if dpi > 0 {
+		params.Density.Set(dpi)
 	}
 	var err error
 	var img *Image
@@ -255,10 +255,10 @@ func (v *Processor) newThumbnailFallback(
 }
 
 // NewImage creates new Image from imagor.Blob
-func (v *Processor) NewImage(ctx context.Context, blob *imagor.Blob, n, page int, dpi *int) (*Image, error) {
+func (v *Processor) NewImage(ctx context.Context, blob *imagor.Blob, n, page int, dpi int) (*Image, error) {
 	var params = NewImportParams()
-	if dpi != nil {
-		params.Density.Set(*dpi)
+	if dpi > 0 {
+		params.Density.Set(dpi)
 	}
 	params.FailOnError.Set(false)
 	if isMultiPage(blob, n, page) {


### PR DESCRIPTION
By default, PDF files are converted to JPEG with a very low dpi of 72. This change allows us to increase the dpi when converting PDFs.