### PR TITLE
feat(awsconfig): support AWS_SESSION_TOKEN

### DIFF
--- a/config/awsconfig/awsconfig.go
+++ b/config/awsconfig/awsconfig.go
@@ -19,6 +19,8 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"AWS Access Key ID. Required if using S3 Loader or Storage")
 		awsSecretAccessKey = fs.String("aws-secret-access-key", "",
 			"AWS Secret Access Key. Required if using S3 Loader or Storage")
+		awsSessionToken = fs.String("aws-session-token", "",
+			"AWS Session Token. Optional temporary credentials token")
 		s3Endpoint = fs.String("s3-endpoint", "",
 			"Optional S3 Endpoint to override default")
 
@@ -28,6 +30,8 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"AWS Access Key ID for S3 Loader to override global config")
 		awsLoaderSecretAccessKey = fs.String("aws-loader-secret-access-key", "",
 			"AWS Secret Access Key for S3 Loader to override global config")
+		awsLoaderSessionToken = fs.String("aws-loader-session-token", "",
+			"AWS Session Token for S3 Loader to override global config")
 		s3LoaderEndpoint = fs.String("s3-loader-endpoint", "",
 			"Optional S3 Loader Endpoint to override default")
 
@@ -37,6 +41,8 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"AWS Access Key ID for S3 Storage to override global config")
 		awsStorageSecretAccessKey = fs.String("aws-storage-secret-access-key", "",
 			"AWS Secret Access Key for S3 Storage to override global config")
+		awsStorageSessionToken = fs.String("aws-storage-session-token", "",
+			"AWS Session Token for S3 Storage to override global config")
 		s3StorageEndpoint = fs.String("s3-storage-endpoint", "",
 			"Optional S3 Storage Endpoint to override default")
 
@@ -46,6 +52,8 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"AWS Access Key ID for S3 Result Storage to override global config")
 		awsResultStorageSecretAccessKey = fs.String("aws-result-storage-secret-access-key", "",
 			"AWS Secret Access Key for S3 Result Storage to override global config")
+		awsResultStorageSessionToken = fs.String("aws-result-storage-session-token", "",
+			"AWS Session Token for S3 Result Storage to override global config")
 		s3ResultStorageEndpoint = fs.String("s3-result-storage-endpoint", "",
 			"Optional S3 Storage Endpoint to override default")
 
@@ -91,7 +99,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 		}
 		var loaderSess, storageSess, resultStorageSess *session.Session
 		var cred = credentials.NewStaticCredentials(
-			*awsAccessKeyID, *awsSecretAccessKey, "")
+			*awsAccessKeyID, *awsSecretAccessKey, *awsSessionToken)
 		var options = session.Options{
 			SharedConfigState: session.SharedConfigEnable,
 		}
@@ -115,7 +123,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 				Endpoint: s3LoaderEndpoint,
 				Region:   awsLoaderRegion,
 				Credentials: credentials.NewStaticCredentials(
-					*awsLoaderAccessKeyID, *awsLoaderSecretAccessKey, ""),
+					*awsLoaderAccessKeyID, *awsLoaderSecretAccessKey, *awsLoaderSessionToken),
 				S3ForcePathStyle: s3ForcePathStyle,
 			}
 			// activate AWS Session only if credentials present
@@ -126,7 +134,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 				Endpoint: s3StorageEndpoint,
 				Region:   awsStorageRegion,
 				Credentials: credentials.NewStaticCredentials(
-					*awsStorageAccessKeyID, *awsStorageSecretAccessKey, ""),
+					*awsStorageAccessKeyID, *awsStorageSecretAccessKey, *awsStorageSessionToken),
 				S3ForcePathStyle: s3ForcePathStyle,
 			}
 			// activate AWS Session only if credentials present
@@ -137,7 +145,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 				Endpoint: s3ResultStorageEndpoint,
 				Region:   awsResultStorageRegion,
 				Credentials: credentials.NewStaticCredentials(
-					*awsResultStorageAccessKeyID, *awsResultStorageSecretAccessKey, ""),
+					*awsResultStorageAccessKeyID, *awsResultStorageSecretAccessKey, *awsResultStorageSessionToken),
 				S3ForcePathStyle: s3ForcePathStyle,
 			}
 			// activate AWS Session only if credentials present


### PR DESCRIPTION
This PR adds support for the AWS_SESSION_TOKEN parameter used in short-lived session authentication in AWS. 
Its usage is explained here in detail:
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html

In my case, we use AWS SSO that creates temporary sessions with AWS_SESSION_TOKEN. 
In order to run the s3 docker compose example as my user I must send this token along with the regular AWS key and id.