### PR TITLE
s3: storage class for files in result storage bucket

### DIFF
--- a/config/awsconfig/awsconfig.go
+++ b/config/awsconfig/awsconfig.go
@@ -2,6 +2,7 @@ package awsconfig
 
 import (
 	"flag"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -90,6 +91,8 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"Upload ACL for S3 Result Storage")
 		s3ResultStorageExpiration = fs.Duration("s3-result-storage-expiration", 0,
 			"S3 Result Storage expiration duration e.g. 24h. Default no expiration")
+		s3FileStorageClass = fs.String("s3-file-storage-class", "STANDARD",
+			"S3 File Storage Class. Available values: reduced-redunancy, standard-ia, intelligent-tiering, glacier, deep_archive. Default: standard.")
 
 		_, _ = cb()
 	)
@@ -182,6 +185,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 					s3storage.WithACL(*s3ResultStorageACL),
 					s3storage.WithSafeChars(*s3SafeChars),
 					s3storage.WithExpiration(*s3ResultStorageExpiration),
+					s3storage.WithFileStorageClass(*s3FileStorageClass),
 				),
 			)
 		}

--- a/config/awsconfig/awsconfig.go
+++ b/config/awsconfig/awsconfig.go
@@ -92,7 +92,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 		s3ResultStorageExpiration = fs.Duration("s3-result-storage-expiration", 0,
 			"S3 Result Storage expiration duration e.g. 24h. Default no expiration")
 		s3FileStorageClass = fs.String("s3-file-storage-class", "STANDARD",
-			"S3 File Storage Class. Available values: reduced-redunancy, standard-ia, intelligent-tiering, glacier, deep_archive. Default: standard.")
+			"S3 File Storage Class. Available values: REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE. Default: STANDARD.")
 
 		_, _ = cb()
 	)

--- a/config/awsconfig/awsconfig.go
+++ b/config/awsconfig/awsconfig.go
@@ -91,7 +91,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"Upload ACL for S3 Result Storage")
 		s3ResultStorageExpiration = fs.Duration("s3-result-storage-expiration", 0,
 			"S3 Result Storage expiration duration e.g. 24h. Default no expiration")
-		s3FileStorageClass = fs.String("s3-file-storage-class", "STANDARD",
+		s3StorageClass = fs.String("s3-storage-class", "STANDARD",
 			"S3 File Storage Class. Available values: REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE. Default: STANDARD.")
 
 		_, _ = cb()
@@ -163,6 +163,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 					s3storage.WithACL(*s3StorageACL),
 					s3storage.WithSafeChars(*s3SafeChars),
 					s3storage.WithExpiration(*s3StorageExpiration),
+					s3storage.WithStorageClass(*s3StorageClass),
 				),
 			)
 		}
@@ -185,7 +186,7 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 					s3storage.WithACL(*s3ResultStorageACL),
 					s3storage.WithSafeChars(*s3SafeChars),
 					s3storage.WithExpiration(*s3ResultStorageExpiration),
-					s3storage.WithFileStorageClass(*s3FileStorageClass),
+					s3storage.WithStorageClass(*s3StorageClass),
 				),
 			)
 		}

--- a/config/awsconfig/awsconfig_test.go
+++ b/config/awsconfig/awsconfig_test.go
@@ -1,11 +1,12 @@
 package awsconfig
 
 import (
+	"testing"
+
 	"github.com/cshum/imagor"
 	"github.com/cshum/imagor/config"
 	"github.com/cshum/imagor/storage/s3storage"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestS3Empty(t *testing.T) {
@@ -119,4 +120,45 @@ func TestS3SessionOverride(t *testing.T) {
 	assert.Equal(t, "/bar/", resultStorage.BaseDir)
 	assert.Equal(t, "/bcda/", resultStorage.PathPrefix)
 	assert.Equal(t, "!", resultStorage.SafeChars)
+}
+
+func TestS3StorageClassWithResultStorageBucket(t *testing.T) {
+	srv := config.CreateServer([]string{
+		"-s3-storage-class", "asdf",
+		"-s3-storage-bucket", "a",
+		"-s3-result-storage-bucket", "b",
+	}, WithAWS)
+	app := srv.App.(*imagor.Imagor)
+	storage := app.Storages[0].(*s3storage.S3Storage)
+	assert.Equal(t, "STANDARD", storage.StorageClass)
+
+}
+
+func TestS3StorageClassWithoutResultStorageBucket(t *testing.T) {
+	srv := config.CreateServer([]string{
+		"-s3-storage-class", "asdf",
+		"-s3-storage-bucket", "a",
+	}, WithAWS)
+	app := srv.App.(*imagor.Imagor)
+	storage := app.Storages[0].(*s3storage.S3Storage)
+	assert.Equal(t, "STANDARD", storage.StorageClass)
+
+}
+
+func TestS3StorageClass(t *testing.T) {
+	srv := config.CreateServer([]string{
+		"-s3-storage-class", "asdf",
+		"-s3-storage-bucket", "a",
+	}, WithAWS)
+	app := srv.App.(*imagor.Imagor)
+	storage := app.Storages[0].(*s3storage.S3Storage)
+	assert.Equal(t, "STANDARD", storage.StorageClass)
+
+	srv = config.CreateServer([]string{
+		"-s3-storage-class", "REDUCED_REDUNDANCY",
+		"-s3-storage-bucket", "a",
+	}, WithAWS)
+	app = srv.App.(*imagor.Imagor)
+	storage = app.Storages[0].(*s3storage.S3Storage)
+	assert.Equal(t, "REDUCED_REDUNDANCY", storage.StorageClass)
 }

--- a/storage/s3storage/option.go
+++ b/storage/s3storage/option.go
@@ -72,23 +72,17 @@ func WithExpiration(exp time.Duration) Option {
 	}
 }
 
+// WithFileStorageClass with storage storage class option
 func WithFileStorageClass(storageClass string) Option {
 	return func(h *S3Storage) {
-		switch storageClass {
-		case "reduced-redunancy":
-			h.StorageClass = "REDUCED_REDUNDANCY"
-		case "standard-ia":
-			h.StorageClass = "STANDARD_IA"
-		case "onezone-ia":
-			h.StorageClass = "ONEZONE_IA"
-		case "intelligent-tiering":
-			h.StorageClass = "INTELLIGENT_TIERING"
-		case "glacier":
-			h.StorageClass = "GLACIER"
-		case "deep-archive":
-			h.StorageClass = "DEEP_ARCHIVE"
-		default:
-			h.StorageClass = "STANDARD"
+		allowedStorageClasses := [6]string{"REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA",
+			"INTELLIGENT_TIERING", "GLACIER", "DEEP_ARCHIVE"}
+		h.StorageClass = "STANDARD"
+		for _, allowedStorageClass := range allowedStorageClasses {
+			if storageClass == allowedStorageClass {
+				h.StorageClass = storageClass
+				break
+			}
 		}
 	}
 }

--- a/storage/s3storage/option.go
+++ b/storage/s3storage/option.go
@@ -73,7 +73,7 @@ func WithExpiration(exp time.Duration) Option {
 }
 
 // WithFileStorageClass with storage storage class option
-func WithFileStorageClass(storageClass string) Option {
+func WithStorageClass(storageClass string) Option {
 	return func(h *S3Storage) {
 		allowedStorageClasses := [6]string{"REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA",
 			"INTELLIGENT_TIERING", "GLACIER", "DEEP_ARCHIVE"}

--- a/storage/s3storage/option.go
+++ b/storage/s3storage/option.go
@@ -1,9 +1,10 @@
 package s3storage
 
 import (
-	"github.com/aws/aws-sdk-go/service/s3"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 // Option S3Storage option
@@ -67,6 +68,27 @@ func WithExpiration(exp time.Duration) Option {
 	return func(h *S3Storage) {
 		if exp > 0 {
 			h.Expiration = exp
+		}
+	}
+}
+
+func WithFileStorageClass(storageClass string) Option {
+	return func(h *S3Storage) {
+		switch storageClass {
+		case "reduced-redunancy":
+			h.StorageClass = "REDUCED_REDUNDANCY"
+		case "standard-ia":
+			h.StorageClass = "STANDARD_IA"
+		case "onezone-ia":
+			h.StorageClass = "ONEZONE_IA"
+		case "intelligent-tiering":
+			h.StorageClass = "INTELLIGENT_TIERING"
+		case "glacier":
+			h.StorageClass = "GLACIER"
+		case "deep-archive":
+			h.StorageClass = "DEEP_ARCHIVE"
+		default:
+			h.StorageClass = "STANDARD"
 		}
 	}
 }


### PR DESCRIPTION
More about Storage Class:
https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html

Briefly from `aws-sdk-go`:
```
By default, Amazon S3 uses the STANDARD Storage Class to store newly created
objects. The STANDARD storage class provides high durability and high availability.
Depending on performance needs, you can specify a different Storage Class.
Amazon S3 on Outposts only uses the OUTPOSTS Storage Class. For more information,
see Storage Classes (https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html) 
in the Amazon S3 User Guide.
```
