### PR TITLE
handle resizing watermarks

### DIFF
--- a/vips/filter.go
+++ b/vips/filter.go
@@ -48,7 +48,7 @@ func (v *Processor) watermark(ctx context.Context, img *Image, load imagor.LoadF
 			h = img.PageHeight() * h / 100
 		}
 		if overlay, err = v.NewThumbnail(
-			ctx, blob, w, h, InterestingNone, SizeDown, n, 1, 0,
+			ctx, blob, w, h, InterestingNone, SizeBoth, n, 1, 0,
 		); err != nil {
 			return
 		}


### PR DESCRIPTION
Similar to https://github.com/cshum/imagor/pull/398 without the image changes and rebased off of master.

Using this to upscale watermarks on a wide range of image sizes. I believe this matches the behavior of thumbor.