### PR TITLE
support vips avif speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,4 +809,6 @@ Usage of imagor:
         VIPS max image resolution
   -vips-mozjpeg
         VIPS enable maximum compression with MozJPEG. Requires mozjpeg to be installed
+  -vips-avif-speed int
+        VIPS avif speed, the lowest is at 0 and the fastest is at 9 (Default 5).
 ```

--- a/config/vipsconfig/vipsconfig.go
+++ b/config/vipsconfig/vipsconfig.go
@@ -34,6 +34,8 @@ func WithVips(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"VIPS max image resolution")
 		vipsMozJPEG = fs.Bool("vips-mozjpeg", false,
 			"VIPS enable maximum compression with MozJPEG. Requires mozjpeg to be installed")
+		vipsAvifSpeed = fs.Int("vips-avif-speed", 5,
+			"VIPS avif speed, the lowest is at 0 and the fastest is at 9 (Default 5).")
 
 		logger, isDebug = cb()
 	)
@@ -51,6 +53,7 @@ func WithVips(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			vips.WithMaxHeight(*vipsMaxHeight),
 			vips.WithMaxResolution(*vipsMaxResolution),
 			vips.WithMozJPEG(*vipsMozJPEG),
+			vips.WithAvifSpeed(*vipsAvifSpeed),
 			vips.WithLogger(logger),
 			vips.WithDebug(isDebug),
 		),

--- a/vips/option.go
+++ b/vips/option.go
@@ -44,6 +44,15 @@ func WithMozJPEG(enabled bool) Option {
 	}
 }
 
+// WithAvifSpeed with avif speed option
+func WithAvifSpeed(avifSpeed int) Option {
+	return func(v *Processor) {
+		if avifSpeed >= 0 && avifSpeed <= 9 {
+			v.AvifSpeed = avifSpeed
+		}
+	}
+}
+
 // WithMaxFilterOps with maximum number of filter operations option
 func WithMaxFilterOps(num int) Option {
 	return func(v *Processor) {

--- a/vips/option_test.go
+++ b/vips/option_test.go
@@ -20,6 +20,7 @@ func TestWithOption(t *testing.T) {
 			WithMaxHeight(998),
 			WithMaxResolution(1666667),
 			WithMozJPEG(true),
+			WithAvifSpeed(9),
 			WithDebug(true),
 			WithMaxAnimationFrames(3),
 			WithDisableFilters("rgb", "fill, watermark"),
@@ -37,6 +38,7 @@ func TestWithOption(t *testing.T) {
 		assert.Equal(t, 1666667, v.MaxResolution)
 		assert.Equal(t, 3, v.MaxAnimationFrames)
 		assert.Equal(t, true, v.MozJPEG)
+		assert.Equal(t, 9, v.AvifSpeed)
 		assert.Equal(t, []string{"rgb", "fill", "watermark"}, v.DisableFilters)
 
 	})

--- a/vips/process.go
+++ b/vips/process.go
@@ -616,6 +616,7 @@ func (v *Processor) export(
 		if quality > 0 {
 			opts.Quality = quality
 		}
+		opts.Speed = v.AvifSpeed
 		return image.ExportAvif(opts)
 	case ImageTypeHEIF:
 		opts := NewHeifExportParams()

--- a/vips/processor.go
+++ b/vips/processor.go
@@ -36,6 +36,7 @@ type Processor struct {
 	MaxResolution      int
 	MaxAnimationFrames int
 	MozJPEG            bool
+	AvifSpeed          int
 	Debug              bool
 
 	disableFilters map[string]bool


### PR DESCRIPTION
This PR try to add avif speed for imagor.

It's said imagor [doesn't support avif speed](https://imgproxy.net/blog/image-processing-servers-benchmark/), while similar [image cdns](https://web.dev/articles/image-cdns) like thumbor and imgproxy do support.
In a test with [wrk](https://github.com/wg/wrk), imagor is faster than thumbor and imgproxy, and with a smallest Stdev.

Please note, libvips has changed to parameter from `speed` to `effort` in 2021, however, `speed` still works.
ref 1: https://www.libvips.org/API/current/VipsForeignSave.html#vips-heifsave-buffer
ref 2: https://github.com/libvips/libvips/blob/master/libvips/foreign/heifsave.c
(libvips would convert `effort` to `speed` again for `heif`'s api. :-)

BTW, `heif` support different `speed` for different `codec`:
aom 0-9, https://github.com/strukturag/libheif/blob/master/libheif/plugins/encoder_aom.cc
rav1e 0-10, https://github.com/strukturag/libheif/blob/master/libheif/plugins/encoder_rav1e.cc
svt 0-13, https://github.com/strukturag/libheif/blob/master/libheif/plugins/encoder_svt.cc


