### PR TITLE
remove metada for webp

### DIFF
--- a/vips/process.go
+++ b/vips/process.go
@@ -598,6 +598,7 @@ func (v *Processor) export(
 		if quality > 0 {
 			opts.Quality = quality
 		}
+		opts.StripMetadata = true
 		return image.ExportWebp(opts)
 	case ImageTypeTIFF:
 		opts := NewTiffExportParams()


### PR DESCRIPTION
For webp, it should be safe to remove metadata, and `cwebp` remove metadata default.

And for image without exif, even if `strip` is unspecified, an empty exif will be added, it's about 212 byte.