### PR TITLE
strip metadata for webp and avif

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -159,7 +159,11 @@ int set_gifsave_options(VipsOperation *operation, SaveParams *params) {
 int set_avifsave_options(VipsOperation *operation, SaveParams *params) {
   int ret = vips_object_set(
       VIPS_OBJECT(operation), "compression", VIPS_FOREIGN_HEIF_COMPRESSION_AV1,
-      "lossless", params->heifLossless, "speed", params->avifSpeed, NULL);
+      "lossless", params->heifLossless,
+      "effort", 9 - params->avifSpeed, // speed is deprecated
+      "strip", params->stripMetadata,
+      "subsample_mode", VIPS_FOREIGN_SUBSAMPLE_AUTO, // set to auto as we always set lossless
+      NULL);
 
   if (!ret && params->quality) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -231,6 +231,7 @@ func vipsSaveAVIFToBuffer(in *C.VipsImage, params AvifExportParams) ([]byte, err
 	p.inputImage = in
 	p.outputFormat = C.AVIF
 	p.quality = C.int(params.Quality)
+	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
 	p.heifLossless = C.int(boolToInt(params.Lossless))
 	p.avifSpeed = C.int(params.Speed)
 
@@ -254,6 +255,7 @@ func vipsSaveGIFToBuffer(in *C.VipsImage, params GifExportParams) ([]byte, error
 	p := C.create_save_params(C.GIF)
 	p.inputImage = in
 	p.quality = C.int(params.Quality)
+	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
 	p.gifDither = C.double(params.Dither)
 	p.gifEffort = C.int(params.Effort)
 	p.gifBitdepth = C.int(params.Bitdepth)

--- a/vips/process.go
+++ b/vips/process.go
@@ -313,7 +313,7 @@ func (v *Processor) Process(
 	}
 	format = supportedSaveFormat(format) // convert to supported export format
 	for {
-		buf, err := v.export(img, format, compression, quality, palette, bitdepth)
+		buf, err := v.export(img, format, compression, quality, palette, bitdepth, stripExif)
 		if err != nil {
 			return nil, WrapErr(err)
 		}
@@ -575,7 +575,7 @@ func supportedSaveFormat(format ImageType) ImageType {
 }
 
 func (v *Processor) export(
-	image *Image, format ImageType, compression int, quality int, palette bool, bitdepth int,
+	image *Image, format ImageType, compression int, quality int, palette bool, bitdepth int, stripExif bool,
 ) ([]byte, error) {
 	switch format {
 	case ImageTypePNG:
@@ -598,6 +598,9 @@ func (v *Processor) export(
 		if quality > 0 {
 			opts.Quality = quality
 		}
+		if stripExif {
+			opts.StripMetadata = true
+		}
 		return image.ExportWebp(opts)
 	case ImageTypeTIFF:
 		opts := NewTiffExportParams()
@@ -615,6 +618,9 @@ func (v *Processor) export(
 		opts := NewAvifExportParams()
 		if quality > 0 {
 			opts.Quality = quality
+		}
+		if stripExif {
+			opts.StripMetadata = true
 		}
 		opts.Speed = v.AvifSpeed
 		return image.ExportAvif(opts)


### PR DESCRIPTION
webp and avif is mainly for browser, it's safe to strip metadata.

@cshum Should we add a new option to do so?
Or make filters strip_exif as an option?