### PR TITLE
Add resize_mode option to watermark filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ imagor supports the following filters:
 - `strip_icc()` removes ICC profile information from the resulting image
 - `strip_metadata()` removes all metadata from the resulting image
 - `upscale()` upscale the image if `fit-in` is used
-- `watermark(image, x, y, alpha [, w_ratio [, h_ratio]])` adds a watermark to the image. It can be positioned inside the image with the alpha channel specified and optionally resized based on the image size by specifying the ratio
+- `watermark(image, x, y, alpha [, w_ratio [, h_ratio [, resize_mode]]])` adds a watermark to the image. It can be positioned inside the image with the alpha channel specified and optionally resized based on the image size by specifying the ratio
   - `image` watermark image URI, using the same image loader configured for imagor
   - `x` horizontal position that the watermark will be in:
     - Positive number indicate position from the left, negative number from the right.
@@ -149,6 +149,7 @@ imagor supports the following filters:
   - `alpha` watermark image transparency, a number between 0 (fully opaque) and 100 (fully transparent).
   - `w_ratio` percentage of the width of the image the watermark should fit-in
   - `h_ratio` percentage of the height of the image the watermark should fit-in
+  - `resize_mode` resize mode of the watermark. If 'force', the watermark will be resized to w_ratio and h_ratio regardless of the watermark's aspect ratio. Otherwise, the watermark will be resized to fit within the w_ratio and h_ratio, respecting its aspect ratio.
 
 #### Utility Filters
 

--- a/vips/filter.go
+++ b/vips/filter.go
@@ -32,8 +32,13 @@ func (v *Processor) watermark(ctx context.Context, img *Image, load imagor.LoadF
 	var down = 1
 	var overlay *Image
 	var n = 1
+	resizeMode := SizeBoth
 	if isAnimated(img) {
 		n = -1
+	}
+	// resize_mode
+	if ln >= 7 && args[6] == "force" {
+		resizeMode = SizeForce
 	}
 	// w_ratio h_ratio
 	if ln >= 6 {
@@ -47,8 +52,9 @@ func (v *Processor) watermark(ctx context.Context, img *Image, load imagor.LoadF
 			h, _ = strconv.Atoi(args[5])
 			h = img.PageHeight() * h / 100
 		}
+
 		if overlay, err = v.NewThumbnail(
-			ctx, blob, w, h, InterestingNone, SizeBoth, n, 1, 0,
+			ctx, blob, w, h, InterestingNone, resizeMode, n, 1, 0,
 		); err != nil {
 			return
 		}


### PR DESCRIPTION
I needed the ability to resize a watermark to the full size of the source image, ignoring the watermark's aspect ratio. This PR allows you to do this:

```
http://localhost:8000/unsafe/0x0:800x500/fit-in/500x0/filters:watermark(https://ucarecdn.com/3ebe2903-f913-4293-9228-2ec723dbb175/,center,center,0,100,100,force)/https://ucarecdn.com/638d660f-3759-494d-9ae3-08eddf68bd49/
```

Before this change:

![image](https://github.com/user-attachments/assets/72eb0bad-cdc0-4029-86e8-05794faaf20a)

After this change:

![image](https://github.com/user-attachments/assets/1710a783-14f8-4cd6-8a6d-8ec06adbad47)
