### PR TITLE
feat: Support buffered fallback for ImageMagick

### DIFF
--- a/vips/processor.go
+++ b/vips/processor.go
@@ -168,6 +168,18 @@ func newImageFromBlob(
 		}()
 		return loadImageFromBMP(r)
 	}
+	if blob.BlobType() == imagor.BlobTypeUnknown {
+		// fallback with buffer to local file for possible imagemagick loader
+		src.Close()
+		r, _, err := blob.NewReader()
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = r.Close()
+		}()
+		return LoadImageFromBufferedFile(r, params)
+	}
 	return img, err
 }
 

--- a/vips/vips.go
+++ b/vips/vips.go
@@ -78,6 +78,21 @@ func vipsImageFromMemory(buf []byte, width, height, bands int) (*C.VipsImage, Im
 	return out, ImageTypeUnknown, nil
 }
 
+// https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file
+func vipsImageFromFile(filePath string) (*C.VipsImage, ImageType, error) {
+	var out *C.VipsImage
+	cFilePath := C.CString(filePath)
+	defer freeCString(cFilePath)
+
+	code := C.image_new_from_file(cFilePath, &out)
+	if code != 0 {
+		return nil, ImageTypeUnknown, handleImageError(out)
+	}
+
+	imageType := vipsDetermineImageTypeFromMetaLoader(out)
+	return out, imageType, nil
+}
+
 // https://www.libvips.org/API/current/libvips-resample.html#vips-thumbnail-source
 func vipsThumbnailFromSource(
 	src *C.VipsSourceCustom, width, height int, crop Interesting, size Size, params *ImportParams) (*C.VipsImage, ImageType, error) {
@@ -298,7 +313,7 @@ func vipsReplicate(in *C.VipsImage, across int, down int) (*C.VipsImage, error) 
 	return out, nil
 }
 
-//  https://libvips.github.io/libvips/API/current/libvips-arithmetic.html#vips-linear
+// https://libvips.github.io/libvips/API/current/libvips-arithmetic.html#vips-linear
 func vipsLinear(in *C.VipsImage, a, b []float64, n int) (*C.VipsImage, error) {
 	var out *C.VipsImage
 


### PR DESCRIPTION
`vips_image_new_from_source` doesn't appear to work in combination with the libvips ImageMagick loader. However, `vips_image_new_from_file` does.

I stumbled on this while testing imagor on newer RAW camera files, like the CR3 file [found here](https://www.imaging-resource.com/PRODS/canon-eos-r7/FULLRES/Y-JG-CANON-EOS-R7-0002.CR3). Without these changes, `libvips` fails to load the images. With the changes, it succeeds.

At a high level, this adds support for a buffered-file fallback if `libvips` fails to load the blob as a source and the blob is of unknown type. The file is kept only long enough to create the Image.

I tried a few different ways to do this, but this felt the least intrusive. I'm happy to try a different approach if you feel there is a better insertion point.