### PR TITLE
feat(build): Support ImageMagick in docker build

### DIFF
--- a/docker/scripts/build-imagemagick.sh
+++ b/docker/scripts/build-imagemagick.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Exit early if ImageMagick is not enabled
+if [[ "${IMAGE_MAGICK_ENABLED}" != "1" ]]; then
+    echo "Skipping ImageMagick build..."
+    exit 0
+fi
+
+# libltdl-dev is needed for ImageMagick build process
+DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -y \
+  libltdl-dev
+
+t=$(mktemp)
+wget 'https://dist.1-2.dev/imei.sh' -qO "$t"
+bash "$t" --imagemagick-version $IMAGE_MAGICK_VERSION
+rm "$t"
+cat /var/log/imei-*

--- a/docker/scripts/build-libraw.sh
+++ b/docker/scripts/build-libraw.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+# If ImageMagick is not included, then we don't need to build libraw. Libvips doesn't use it
+if [[ "${IMAGE_MAGICK_ENABLED}" != "1" ]]; then
+    echo "Skipping libraw build because ImageMagick is not required..."
+    exit 0
+fi
+
+# We build libraw from scratch because the debian bookworm package is too old
+cd /tmp
+curl -fsSLO https://github.com/LibRaw/LibRaw/archive/refs/tags/${LIBRAW_VERSION}.tar.gz
+tar xf ${LIBRAW_VERSION}.tar.gz
+cd LibRaw-${LIBRAW_VERSION}
+ls -la
+
+# libtool is needed for libraw build process
+DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -y \
+  libtool
+
+# https://github.com/LibRaw/LibRaw/blob/master/INSTALL
+autoreconf --install
+./configure
+make install
+cd .. && rm -rf libraw
+#ldconfig /usr/local/lib
+ldconfig

--- a/docker/scripts/build-libvips.sh
+++ b/docker/scripts/build-libvips.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd /tmp
+curl -fsSLO https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz
+tar xf vips-${VIPS_VERSION}.tar.xz
+cd vips-${VIPS_VERSION}
+
+# Determine whether to enable or disable ImageMagick support
+if [[ "${IMAGE_MAGICK_ENABLED}" == "1" ]]; then
+    MAGICK_OPTION="enabled"
+else
+    MAGICK_OPTION="disabled"
+fi
+
+meson setup _build \
+--buildtype=release \
+--strip \
+--prefix=/usr/local \
+--libdir=lib \
+-Dgtk_doc=false \
+-Dmagick=${MAGICK_OPTION} \
+-Dintrospection=disabled
+ninja -C _build
+ninja -C _build install
+ldconfig
+rm -rf /usr/local/lib/libvips-cpp.*
+rm -rf /usr/local/lib/*.a
+rm -rf /usr/local/lib/*.la


### PR DESCRIPTION
The current `Dockerfile` appears to intentionally disable support for the `magickloader` when building `libvips`. This makes sense from a default security sense.

However, it would be nice if an `ImageMagick` variant was built for those that wanted it. This PR modifies the Dockerfile to allow passing of an ARG to enable `ImageMagick`. 

Notable changes:
1. Add ARGs for enabling ImageMagick and specifting versions
2. Move build logic into bash scripts for easier refactoring
3. Conditionally build `libraw`
4. Conditionally build `ImageMagick` using `imei`


Most of the required ImageMagick libs for processing are already included because the previous Dockerfile installed them for libvips anyways. So those didn't have to change.

Note: This PR *does not update the corresponding build workflows*. It would be nice if those are updated to produce a new tag by default if these changes are accepted, but I didn't want to modify workflows that don't run on my fork.