### PR TITLE
feat: add auto JPEG format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,8 @@ Usage of imagor:
         Output WebP format automatically if browser supports
   -imagor-auto-avif
         Output AVIF format automatically if browser supports (experimental)
+  -imagor-auto-jpeg
+        Output JPEG format automatically if JPEG or no specific format is requested
   -imagor-base-params string
         imagor endpoint base params that applies to all resulting images e.g. filters:watermark(example.jpg)
   -imagor-signer-type string

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,8 @@ func NewImagor(
 			"Output WebP format automatically if browser supports")
 		imagorAutoAVIF = fs.Bool("imagor-auto-avif", false,
 			"Output AVIF format automatically if browser supports (experimental)")
+		imagorAutoJPEG = fs.Bool("imagor-auto-jpeg", false,
+			"Output JPEG format automatically if JPEG or no specific format is requested")
 		imagorRequestTimeout = fs.Duration("imagor-request-timeout",
 			time.Second*30, "Timeout for performing imagor request")
 		imagorLoadTimeout = fs.Duration("imagor-load-timeout",
@@ -113,6 +115,7 @@ func NewImagor(
 		imagor.WithCacheHeaderNoCache(*imagorCacheHeaderNoCache),
 		imagor.WithAutoWebP(*imagorAutoWebP),
 		imagor.WithAutoAVIF(*imagorAutoAVIF),
+		imagor.WithAutoJPEG(*imagorAutoJPEG),
 		imagor.WithModifiedTimeCheck(*imagorModifiedTimeCheck),
 		imagor.WithDisableErrorBody(*imagorDisableErrorBody),
 		imagor.WithDisableParamsEndpoint(*imagorDisableParamsEndpoint),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ func TestDefault(t *testing.T) {
 	assert.False(t, app.ModifiedTimeCheck)
 	assert.False(t, app.AutoWebP)
 	assert.False(t, app.AutoAVIF)
+	assert.False(t, app.AutoJPEG)
 	assert.False(t, app.DisableErrorBody)
 	assert.False(t, app.DisableParamsEndpoint)
 	assert.Equal(t, time.Hour*24*7, app.CacheHeaderTTL)
@@ -49,6 +50,7 @@ func TestBasic(t *testing.T) {
 		"-imagor-unsafe",
 		"-imagor-auto-webp",
 		"-imagor-auto-avif",
+		"-imagor-auto-jpeg",
 		"-imagor-disable-error-body",
 		"-imagor-disable-params-endpoint",
 		"-imagor-request-timeout", "16s",
@@ -71,6 +73,8 @@ func TestBasic(t *testing.T) {
 	assert.True(t, app.Debug)
 	assert.True(t, app.Unsafe)
 	assert.True(t, app.AutoWebP)
+	assert.True(t, app.AutoAVIF)
+	assert.True(t, app.AutoJPEG)
 	assert.True(t, app.DisableErrorBody)
 	assert.True(t, app.DisableParamsEndpoint)
 	assert.Equal(t, "RrTsWGEXFU2s1J1mTl1j_ciO-1E=", app.Signer.Sign("bar"))

--- a/imagor.go
+++ b/imagor.go
@@ -82,6 +82,7 @@ type Imagor struct {
 	ProcessQueueSize       int64
 	AutoWebP               bool
 	AutoAVIF               bool
+	AutoJPEG               bool
 	ModifiedTimeCheck      bool
 	DisableErrorBody       bool
 	DisableParamsEndpoint  bool
@@ -294,8 +295,8 @@ func (app *Imagor) Do(r *http.Request, p imagorpath.Params) (blob *Blob, err err
 			p.Filters = append(p.Filters, f)
 		}
 	}
-	// auto WebP / AVIF
-	if !hasFormat && (app.AutoWebP || app.AutoAVIF) {
+	// auto WebP / AVIF / JPEG
+	if !hasFormat && (app.AutoWebP || app.AutoAVIF || app.AutoJPEG) {
 		accept := r.Header.Get("Accept")
 		if app.AutoAVIF && strings.Contains(accept, "image/avif") {
 			p.Filters = append(p.Filters, imagorpath.Filter{
@@ -310,6 +311,13 @@ func (app *Imagor) Do(r *http.Request, p imagorpath.Params) (blob *Blob, err err
 				Args: "webp",
 			})
 			r.Header.Set("Imagor-Auto-Format", "webp") // response Vary: Accept header
+			isPathChanged = true
+		} else if app.AutoJPEG && (accept == "" || strings.Contains(accept, "image/jpeg") || strings.Contains(accept, "image/*") || strings.Contains(accept, "*/*")) {
+			p.Filters = append(p.Filters, imagorpath.Filter{
+				Name: "format",
+				Args: "jpeg",
+			})
+			r.Header.Set("Imagor-Auto-Format", "jpeg") // response Vary: Accept header
 			isPathChanged = true
 		}
 	}

--- a/option.go
+++ b/option.go
@@ -160,6 +160,13 @@ func WithAutoAVIF(enable bool) Option {
 	}
 }
 
+// WithAutoJPEG with auto JPEG option when JPEG or no specific format is requested
+func WithAutoJPEG(enable bool) Option {
+	return func(app *Imagor) {
+		app.AutoJPEG = enable
+	}
+}
+
 // WithBasePathRedirect with base path redirect option
 func WithBasePathRedirect(url string) Option {
 	return func(app *Imagor) {


### PR DESCRIPTION
Hello @cshum,

I was looking at imagor as a direct thumbor replacement and stumbled upon a specific behavior that I'm missing:

When thumbor has auto JPEG enabled, it produces a JPEG image when no specific Accept image headers are requested:
https://github.com/thumbor/thumbor/blob/b497209871d04a40304cc14ba2de6f42ffbd1c69/thumbor/handlers/__init__.py#L449C1-L465C21


There's currently no way to achieve this behavior in imagor, as defining default filters would cause us to lose the other auto formats (WebP/AVIF).

I've implemented an option that mimics this behavior (default off). This would also prevent clients from receiving the original image format in most cases, reducing bandwidth requirements and CDN storage costs.



