### PR TITLE
feat: add S3 loader bucket routing with multi-region and fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,79 @@ AWS_RESULT_STORAGE_SECRET_ACCESS_KEY
 S3_RESULT_STORAGE_ENDPOINT
 ```
 
+##### S3 Loader Bucket Routing
+
+For multi-tenant or multi-bucket setups, you can route image requests to different S3 buckets based on path prefix. Each bucket can have its own region, endpoint, and credentials. Create a YAML configuration file:
+
+```yaml
+default_bucket:
+  name: imagor-default
+  region: us-east-1
+
+fallback_buckets:
+  - name: imagor-archive
+    region: us-east-1
+  - name: imagor-legacy
+    region: us-west-2
+
+rules:
+  - prefix: users
+    bucket:
+      name: imagor-users
+      region: eu-west-1
+  - prefix: products
+    bucket:
+      name: imagor-products
+      region: ap-southeast-1
+  - prefix: private/images
+    bucket:
+      name: imagor-private
+      region: us-east-1
+      endpoint: https://s3.custom-endpoint.com
+      access_key_id: AKIAIOSFODNN7EXAMPLE
+      secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+Then specify the config file path:
+
+```dotenv
+S3_LOADER_BUCKET_ROUTER_CONFIG=/path/to/bucket-routing.yaml
+```
+
+Or via command line:
+
+```bash
+imagor -s3-loader-bucket-router-config /path/to/bucket-routing.yaml
+```
+
+Routing behavior:
+- Rules are matched using longest-prefix-first (e.g., `private/images` matches before `private`)
+- If no rule matches, the `default_bucket` is used
+- If image not found in primary bucket, `fallback_buckets` are tried in order (up to 2 fallbacks)
+- Each bucket config can specify its own `region`, `endpoint`, and credentials
+- If bucket-specific credentials are not provided, global AWS credentials are used
+- If `S3_LOADER_BUCKET` is not set, `default_bucket.name` from the config is used
+
+Docker Compose example with bucket routing:
+
+```yaml
+version: "3"
+services:
+  imagor:
+    image: shumc/imagor:latest
+    volumes:
+      - ./bucket-routing.yaml:/etc/imagor/bucket-routing.yaml
+    environment:
+      PORT: 8000
+      IMAGOR_SECRET: mysecret
+      AWS_ACCESS_KEY_ID: ...
+      AWS_SECRET_ACCESS_KEY: ...
+      AWS_REGION: us-east-1
+      S3_LOADER_BUCKET_ROUTER_CONFIG: /etc/imagor/bucket-routing.yaml
+    ports:
+      - "8000:8000"
+```
+
 #### Google Cloud Storage
 
 Docker Compose example with Google Cloud Storage:
@@ -770,6 +843,8 @@ Usage of imagor:
         Base directory for S3 Loader
   -s3-loader-path-prefix string
         Base path prefix for S3 Loader
+  -s3-loader-bucket-router-config string
+        YAML config file for S3 Loader bucket routing based on path prefix
   -s3-result-storage-bucket string
         S3 Bucket for S3 Result Storage. Enable S3 Result Storage only if this value present
   -s3-result-storage-base-dir string

--- a/config/awsconfig/bucket_router.go
+++ b/config/awsconfig/bucket_router.go
@@ -1,0 +1,70 @@
+package awsconfig
+
+import (
+	"os"
+	"strings"
+
+	"github.com/cshum/imagor/storage/s3storage"
+	"gopkg.in/yaml.v3"
+)
+
+type bucketConfigYAML struct {
+	Name            string `yaml:"name"`
+	Region          string `yaml:"region"`
+	Endpoint        string `yaml:"endpoint"`
+	AccessKeyID     string `yaml:"access_key_id"`
+	SecretAccessKey string `yaml:"secret_access_key"`
+	SessionToken    string `yaml:"session_token"`
+}
+
+type bucketRouterConfig struct {
+	DefaultBucket   bucketConfigYAML   `yaml:"default_bucket"`
+	FallbackBuckets []bucketConfigYAML `yaml:"fallback_buckets"`
+	Rules           []struct {
+		Prefix string           `yaml:"prefix"`
+		Bucket bucketConfigYAML `yaml:"bucket"`
+	} `yaml:"rules"`
+}
+
+func LoadBucketRouterFromYAML(path string) (*s3storage.PrefixRouter, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg bucketRouterConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	defaultConfig := toBucketConfig(&cfg.DefaultBucket)
+
+	var fallbacks []*s3storage.BucketConfig
+	for _, fb := range cfg.FallbackBuckets {
+		fallbacks = append(fallbacks, toBucketConfig(&fb))
+	}
+
+	rules := make([]s3storage.PrefixRule, 0, len(cfg.Rules))
+	for _, r := range cfg.Rules {
+		rules = append(rules, s3storage.PrefixRule{
+			Prefix: strings.TrimLeft(r.Prefix, "/"),
+			Config: toBucketConfig(&r.Bucket),
+		})
+	}
+
+	return s3storage.NewPrefixRouter(rules, defaultConfig, fallbacks), nil
+}
+
+func toBucketConfig(y *bucketConfigYAML) *s3storage.BucketConfig {
+	if y == nil || y.Name == "" {
+		return nil
+	}
+	return &s3storage.BucketConfig{
+		Name:            y.Name,
+		Region:          y.Region,
+		Endpoint:        y.Endpoint,
+		AccessKeyID:     y.AccessKeyID,
+		SecretAccessKey: y.SecretAccessKey,
+		SessionToken:    y.SessionToken,
+	}
+}

--- a/config/awsconfig/bucket_router_test.go
+++ b/config/awsconfig/bucket_router_test.go
@@ -1,0 +1,186 @@
+package awsconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBucketRouterFromYAML(t *testing.T) {
+	t.Run("full config with all fields", func(t *testing.T) {
+		yaml := `
+default_bucket:
+  name: default-bucket
+  region: us-east-1
+  endpoint: https://s3.us-east-1.amazonaws.com
+
+fallback_buckets:
+  - name: fallback-1
+    region: us-west-1
+  - name: fallback-2
+    region: eu-west-1
+    endpoint: https://s3.eu-west-1.amazonaws.com
+
+rules:
+  - prefix: users
+    bucket:
+      name: users-bucket
+      region: eu-west-1
+  - prefix: products
+    bucket:
+      name: products-bucket
+      region: ap-southeast-1
+      access_key_id: AKIAIOSFODNN7EXAMPLE
+      secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+`
+		tmpFile := createTempYAML(t, yaml)
+		defer os.Remove(tmpFile)
+
+		router, err := LoadBucketRouterFromYAML(tmpFile)
+		require.NoError(t, err)
+
+		defaultCfg := router.DefaultConfig()
+		assert.Equal(t, "default-bucket", defaultCfg.Name)
+		assert.Equal(t, "us-east-1", defaultCfg.Region)
+		assert.Equal(t, "https://s3.us-east-1.amazonaws.com", defaultCfg.Endpoint)
+
+		fallbacks := router.Fallbacks()
+		assert.Len(t, fallbacks, 2)
+		assert.Equal(t, "fallback-1", fallbacks[0].Name)
+		assert.Equal(t, "us-west-1", fallbacks[0].Region)
+		assert.Equal(t, "fallback-2", fallbacks[1].Name)
+		assert.Equal(t, "eu-west-1", fallbacks[1].Region)
+
+		usersCfg := router.ConfigFor("users/123/image.jpg")
+		assert.Equal(t, "users-bucket", usersCfg.Name)
+		assert.Equal(t, "eu-west-1", usersCfg.Region)
+
+		productsCfg := router.ConfigFor("products/456/image.jpg")
+		assert.Equal(t, "products-bucket", productsCfg.Name)
+		assert.Equal(t, "ap-southeast-1", productsCfg.Region)
+		assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", productsCfg.AccessKeyID)
+		assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", productsCfg.SecretAccessKey)
+
+		otherCfg := router.ConfigFor("other/image.jpg")
+		assert.Equal(t, "default-bucket", otherCfg.Name)
+	})
+
+	t.Run("minimal config", func(t *testing.T) {
+		yaml := `
+default_bucket:
+  name: my-bucket
+  region: us-east-1
+`
+		tmpFile := createTempYAML(t, yaml)
+		defer os.Remove(tmpFile)
+
+		router, err := LoadBucketRouterFromYAML(tmpFile)
+		require.NoError(t, err)
+
+		assert.Equal(t, "my-bucket", router.DefaultConfig().Name)
+		assert.Empty(t, router.Fallbacks())
+
+		cfg := router.ConfigFor("any/path")
+		assert.Equal(t, "my-bucket", cfg.Name)
+	})
+
+	t.Run("fallback limited to 2", func(t *testing.T) {
+		yaml := `
+default_bucket:
+  name: default
+  region: us-east-1
+
+fallback_buckets:
+  - name: fb1
+    region: us-east-1
+  - name: fb2
+    region: us-east-1
+  - name: fb3
+    region: us-east-1
+  - name: fb4
+    region: us-east-1
+`
+		tmpFile := createTempYAML(t, yaml)
+		defer os.Remove(tmpFile)
+
+		router, err := LoadBucketRouterFromYAML(tmpFile)
+		require.NoError(t, err)
+
+		fallbacks := router.Fallbacks()
+		assert.Len(t, fallbacks, 2)
+		assert.Equal(t, "fb1", fallbacks[0].Name)
+		assert.Equal(t, "fb2", fallbacks[1].Name)
+	})
+
+	t.Run("longest prefix wins", func(t *testing.T) {
+		yaml := `
+default_bucket:
+  name: default
+  region: us-east-1
+
+rules:
+  - prefix: media
+    bucket:
+      name: media-bucket
+      region: us-east-1
+  - prefix: media/images
+    bucket:
+      name: images-bucket
+      region: us-east-1
+  - prefix: media/images/thumbnails
+    bucket:
+      name: thumbnails-bucket
+      region: us-east-1
+`
+		tmpFile := createTempYAML(t, yaml)
+		defer os.Remove(tmpFile)
+
+		router, err := LoadBucketRouterFromYAML(tmpFile)
+		require.NoError(t, err)
+
+		assert.Equal(t, "thumbnails-bucket", router.ConfigFor("media/images/thumbnails/123.jpg").Name)
+		assert.Equal(t, "images-bucket", router.ConfigFor("media/images/photo.jpg").Name)
+		assert.Equal(t, "media-bucket", router.ConfigFor("media/video.mp4").Name)
+		assert.Equal(t, "default", router.ConfigFor("other/file.jpg").Name)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := LoadBucketRouterFromYAML("/nonexistent/path.yaml")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		tmpFile := createTempYAML(t, "invalid: yaml: content: [")
+		defer os.Remove(tmpFile)
+
+		_, err := LoadBucketRouterFromYAML(tmpFile)
+		assert.Error(t, err)
+	})
+
+	t.Run("backward compat fallback method", func(t *testing.T) {
+		yaml := `
+default_bucket:
+  name: my-fallback
+  region: us-east-1
+`
+		tmpFile := createTempYAML(t, yaml)
+		defer os.Remove(tmpFile)
+
+		router, err := LoadBucketRouterFromYAML(tmpFile)
+		require.NoError(t, err)
+
+		assert.Equal(t, "my-fallback", router.Fallback())
+	})
+}
+
+func createTempYAML(t *testing.T, content string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "config.yaml")
+	err := os.WriteFile(tmpFile, []byte(content), 0644)
+	require.NoError(t, err)
+	return tmpFile
+}

--- a/storage/s3storage/option.go
+++ b/storage/s3storage/option.go
@@ -102,3 +102,10 @@ func WithForcePathStyle(forcePathStyle bool) Option {
 		s.ForcePathStyle = forcePathStyle
 	}
 }
+
+// WithBucketRouter with bucket router option for prefix-based bucket selection
+func WithBucketRouter(router BucketRouter) Option {
+	return func(s *S3Storage) {
+		s.BucketRouter = router
+	}
+}

--- a/storage/s3storage/router.go
+++ b/storage/s3storage/router.go
@@ -1,0 +1,115 @@
+package s3storage
+
+import (
+	"sort"
+	"strings"
+)
+
+// BucketConfig contains S3 bucket configuration including region and credentials
+type BucketConfig struct {
+	Name            string
+	Region          string
+	Endpoint        string
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
+
+// BucketRouter determines which bucket configuration to use based on the image key
+type BucketRouter interface {
+	// ConfigFor returns the bucket config for the given key
+	ConfigFor(key string) *BucketConfig
+	// Fallbacks returns the list of fallback bucket configs to try if primary fails
+	Fallbacks() []*BucketConfig
+	// DefaultConfig returns the default bucket config
+	DefaultConfig() *BucketConfig
+	// AllConfigs returns all unique bucket configs for client initialization
+	AllConfigs() []*BucketConfig
+}
+
+// PrefixRule maps a path prefix to a bucket config
+type PrefixRule struct {
+	Prefix string
+	Config *BucketConfig
+}
+
+// PrefixRouter routes requests to buckets based on longest-prefix-first matching
+type PrefixRouter struct {
+	rules         []PrefixRule
+	defaultConfig *BucketConfig
+	fallbacks     []*BucketConfig
+}
+
+// NewPrefixRouter creates a PrefixRouter, sorting rules by prefix length descending
+func NewPrefixRouter(rules []PrefixRule, defaultConfig *BucketConfig, fallbacks []*BucketConfig) *PrefixRouter {
+	sorted := make([]PrefixRule, len(rules))
+	copy(sorted, rules)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return len(sorted[i].Prefix) > len(sorted[j].Prefix)
+	})
+
+	// Limit fallbacks to 2
+	if len(fallbacks) > 2 {
+		fallbacks = fallbacks[:2]
+	}
+
+	return &PrefixRouter{
+		rules:         sorted,
+		defaultConfig: defaultConfig,
+		fallbacks:     fallbacks,
+	}
+}
+
+// ConfigFor returns the bucket config for the given key, or default if no prefix matches
+func (r *PrefixRouter) ConfigFor(key string) *BucketConfig {
+	key = strings.TrimLeft(key, "/")
+
+	for _, rule := range r.rules {
+		if strings.HasPrefix(key, rule.Prefix) {
+			return rule.Config
+		}
+	}
+	return r.defaultConfig
+}
+
+// Fallbacks returns the list of fallback bucket configs
+func (r *PrefixRouter) Fallbacks() []*BucketConfig {
+	return r.fallbacks
+}
+
+// DefaultConfig returns the default bucket config
+func (r *PrefixRouter) DefaultConfig() *BucketConfig {
+	return r.defaultConfig
+}
+
+// AllConfigs returns all unique bucket configs for client initialization
+func (r *PrefixRouter) AllConfigs() []*BucketConfig {
+	seen := make(map[string]bool)
+	var configs []*BucketConfig
+
+	addConfig := func(cfg *BucketConfig) {
+		if cfg != nil && !seen[cfg.Name] {
+			seen[cfg.Name] = true
+			configs = append(configs, cfg)
+		}
+	}
+
+	addConfig(r.defaultConfig)
+	for _, rule := range r.rules {
+		addConfig(rule.Config)
+	}
+	for _, fb := range r.fallbacks {
+		addConfig(fb)
+	}
+
+	return configs
+}
+
+// Fallback returns the fallback bucket name (for backward compatibility)
+func (r *PrefixRouter) Fallback() string {
+	if r.defaultConfig != nil {
+		return r.defaultConfig.Name
+	}
+	return ""
+}

--- a/storage/s3storage/router_test.go
+++ b/storage/s3storage/router_test.go
@@ -1,0 +1,207 @@
+package s3storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixRouter_ConfigFor(t *testing.T) {
+	defaultCfg := &BucketConfig{Name: "default-bucket", Region: "us-east-1"}
+	usersCfg := &BucketConfig{Name: "users-bucket", Region: "eu-west-1"}
+	productsCfg := &BucketConfig{Name: "products-bucket", Region: "ap-southeast-1"}
+	vipCfg := &BucketConfig{Name: "vip-bucket", Region: "us-west-2"}
+
+	tests := []struct {
+		name           string
+		rules          []PrefixRule
+		defaultConfig  *BucketConfig
+		key            string
+		expectedBucket string
+	}{
+		{
+			name:           "empty rules returns default",
+			rules:          []PrefixRule{},
+			defaultConfig:  defaultCfg,
+			key:            "users/123/image.jpg",
+			expectedBucket: "default-bucket",
+		},
+		{
+			name: "exact prefix match",
+			rules: []PrefixRule{
+				{Prefix: "users/", Config: usersCfg},
+				{Prefix: "products/", Config: productsCfg},
+			},
+			defaultConfig:  defaultCfg,
+			key:            "users/123/image.jpg",
+			expectedBucket: "users-bucket",
+		},
+		{
+			name: "no match returns default",
+			rules: []PrefixRule{
+				{Prefix: "users/", Config: usersCfg},
+				{Prefix: "products/", Config: productsCfg},
+			},
+			defaultConfig:  defaultCfg,
+			key:            "other/123/image.jpg",
+			expectedBucket: "default-bucket",
+		},
+		{
+			name: "longest prefix wins",
+			rules: []PrefixRule{
+				{Prefix: "users/", Config: usersCfg},
+				{Prefix: "users/vip/", Config: vipCfg},
+			},
+			defaultConfig:  defaultCfg,
+			key:            "users/vip/123/image.jpg",
+			expectedBucket: "vip-bucket",
+		},
+		{
+			name: "strips leading slash from key",
+			rules: []PrefixRule{
+				{Prefix: "users/", Config: usersCfg},
+			},
+			defaultConfig:  defaultCfg,
+			key:            "/users/123/image.jpg",
+			expectedBucket: "users-bucket",
+		},
+		{
+			name: "deep nested prefix",
+			rules: []PrefixRule{
+				{Prefix: "media/images/thumbnails/", Config: &BucketConfig{Name: "thumbnails-bucket"}},
+				{Prefix: "media/images/", Config: &BucketConfig{Name: "images-bucket"}},
+				{Prefix: "media/", Config: &BucketConfig{Name: "media-bucket"}},
+			},
+			defaultConfig:  defaultCfg,
+			key:            "media/images/thumbnails/123.jpg",
+			expectedBucket: "thumbnails-bucket",
+		},
+		{
+			name: "empty key returns default",
+			rules: []PrefixRule{
+				{Prefix: "users/", Config: usersCfg},
+			},
+			defaultConfig:  defaultCfg,
+			key:            "",
+			expectedBucket: "default-bucket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := NewPrefixRouter(tt.rules, tt.defaultConfig, nil)
+			cfg := router.ConfigFor(tt.key)
+			assert.Equal(t, tt.expectedBucket, cfg.Name)
+		})
+	}
+}
+
+func TestPrefixRouter_Fallbacks(t *testing.T) {
+	defaultCfg := &BucketConfig{Name: "default-bucket", Region: "us-east-1"}
+	fb1 := &BucketConfig{Name: "fallback-1", Region: "us-west-1"}
+	fb2 := &BucketConfig{Name: "fallback-2", Region: "eu-west-1"}
+	fb3 := &BucketConfig{Name: "fallback-3", Region: "ap-southeast-1"}
+
+	t.Run("returns fallbacks", func(t *testing.T) {
+		router := NewPrefixRouter(nil, defaultCfg, []*BucketConfig{fb1, fb2})
+		fallbacks := router.Fallbacks()
+		assert.Len(t, fallbacks, 2)
+		assert.Equal(t, "fallback-1", fallbacks[0].Name)
+		assert.Equal(t, "fallback-2", fallbacks[1].Name)
+	})
+
+	t.Run("limits to 2 fallbacks", func(t *testing.T) {
+		router := NewPrefixRouter(nil, defaultCfg, []*BucketConfig{fb1, fb2, fb3})
+		fallbacks := router.Fallbacks()
+		assert.Len(t, fallbacks, 2)
+	})
+
+	t.Run("empty fallbacks", func(t *testing.T) {
+		router := NewPrefixRouter(nil, defaultCfg, nil)
+		fallbacks := router.Fallbacks()
+		assert.Len(t, fallbacks, 0)
+	})
+}
+
+func TestPrefixRouter_AllConfigs(t *testing.T) {
+	defaultCfg := &BucketConfig{Name: "default-bucket", Region: "us-east-1"}
+	usersCfg := &BucketConfig{Name: "users-bucket", Region: "eu-west-1"}
+	fb1 := &BucketConfig{Name: "fallback-1", Region: "us-west-1"}
+
+	rules := []PrefixRule{
+		{Prefix: "users/", Config: usersCfg},
+	}
+
+	router := NewPrefixRouter(rules, defaultCfg, []*BucketConfig{fb1})
+	configs := router.AllConfigs()
+
+	assert.Len(t, configs, 3)
+
+	names := make(map[string]bool)
+	for _, cfg := range configs {
+		names[cfg.Name] = true
+	}
+	assert.True(t, names["default-bucket"])
+	assert.True(t, names["users-bucket"])
+	assert.True(t, names["fallback-1"])
+}
+
+func TestPrefixRouter_AllConfigs_NoDuplicates(t *testing.T) {
+	sharedCfg := &BucketConfig{Name: "shared-bucket", Region: "us-east-1"}
+
+	rules := []PrefixRule{
+		{Prefix: "users/", Config: sharedCfg},
+		{Prefix: "products/", Config: sharedCfg},
+	}
+
+	router := NewPrefixRouter(rules, sharedCfg, []*BucketConfig{sharedCfg})
+	configs := router.AllConfigs()
+
+	assert.Len(t, configs, 1)
+	assert.Equal(t, "shared-bucket", configs[0].Name)
+}
+
+func TestPrefixRouter_Fallback_BackwardCompat(t *testing.T) {
+	defaultCfg := &BucketConfig{Name: "my-fallback", Region: "us-east-1"}
+	router := NewPrefixRouter(nil, defaultCfg, nil)
+	assert.Equal(t, "my-fallback", router.Fallback())
+}
+
+func TestPrefixRouter_Fallback_NilDefault(t *testing.T) {
+	router := NewPrefixRouter(nil, nil, nil)
+	assert.Equal(t, "", router.Fallback())
+}
+
+func TestPrefixRouter_ConfigPreservesRegion(t *testing.T) {
+	euConfig := &BucketConfig{Name: "eu-bucket", Region: "eu-west-1", Endpoint: "https://s3.eu-west-1.amazonaws.com"}
+	apConfig := &BucketConfig{Name: "ap-bucket", Region: "ap-southeast-1"}
+	defaultCfg := &BucketConfig{Name: "default", Region: "us-east-1"}
+
+	rules := []PrefixRule{
+		{Prefix: "europe/", Config: euConfig},
+		{Prefix: "asia/", Config: apConfig},
+	}
+
+	router := NewPrefixRouter(rules, defaultCfg, nil)
+
+	cfg := router.ConfigFor("europe/image.jpg")
+	assert.Equal(t, "eu-bucket", cfg.Name)
+	assert.Equal(t, "eu-west-1", cfg.Region)
+	assert.Equal(t, "https://s3.eu-west-1.amazonaws.com", cfg.Endpoint)
+
+	cfg = router.ConfigFor("asia/image.jpg")
+	assert.Equal(t, "ap-bucket", cfg.Name)
+	assert.Equal(t, "ap-southeast-1", cfg.Region)
+}
+
+func TestPrefixRouter_DoesNotMutateInput(t *testing.T) {
+	rules := []PrefixRule{
+		{Prefix: "b/", Config: &BucketConfig{Name: "bucket-b"}},
+		{Prefix: "a/", Config: &BucketConfig{Name: "bucket-a"}},
+	}
+	originalFirst := rules[0]
+
+	NewPrefixRouter(rules, &BucketConfig{Name: "default"}, nil)
+
+	assert.Equal(t, originalFirst.Prefix, rules[0].Prefix)
+}

--- a/storage/s3storage/s3storage.go
+++ b/storage/s3storage/s3storage.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
@@ -18,10 +20,10 @@ import (
 	"github.com/cshum/imagor/imagorpath"
 )
 
-// S3Storage AWS S3 Storage implements imagor.Storage interface
 type S3Storage struct {
-	Client *s3.Client
-	Bucket string
+	Client       *s3.Client
+	Bucket       string
+	BucketRouter BucketRouter
 
 	BaseDir        string
 	PathPrefix     string
@@ -33,9 +35,12 @@ type S3Storage struct {
 	ForcePathStyle bool
 
 	safeChars imagorpath.SafeChars
+
+	baseConfig aws.Config
+	clients    map[string]*s3.Client
+	clientsMu  sync.RWMutex
 }
 
-// New creates S3Storage
 func New(cfg aws.Config, bucket string, options ...Option) *S3Storage {
 	baseDir := "/"
 	if idx := strings.Index(bucket, "/"); idx > -1 {
@@ -43,7 +48,9 @@ func New(cfg aws.Config, bucket string, options ...Option) *S3Storage {
 		bucket = bucket[:idx]
 	}
 	s := &S3Storage{
-		Bucket: bucket,
+		Bucket:     bucket,
+		baseConfig: cfg,
+		clients:    make(map[string]*s3.Client),
 
 		BaseDir:    baseDir,
 		PathPrefix: "/",
@@ -53,7 +60,6 @@ func New(cfg aws.Config, bucket string, options ...Option) *S3Storage {
 		option(s)
 	}
 
-	// Create S3 client with endpoint and path style options
 	var s3Options []func(*s3.Options)
 	if s.Endpoint != "" {
 		s3Options = append(s3Options, func(o *s3.Options) {
@@ -72,13 +78,91 @@ func New(cfg aws.Config, bucket string, options ...Option) *S3Storage {
 		s.safeChars = imagorpath.NewNoopSafeChars()
 	} else {
 		s.safeChars = imagorpath.NewSafeChars("!\"()*" + s.SafeChars)
-		// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-guidelines-safe-characters
+	}
+
+	if s.BucketRouter != nil {
+		s.initRouterClients()
 	}
 
 	return s
 }
 
-// Path transforms and validates image key for storage path
+func (s *S3Storage) initRouterClients() {
+	for _, cfg := range s.BucketRouter.AllConfigs() {
+		s.getOrCreateClient(cfg)
+	}
+}
+
+func (s *S3Storage) getOrCreateClient(cfg *BucketConfig) *s3.Client {
+	if cfg == nil {
+		return s.Client
+	}
+
+	key := s.clientKey(cfg)
+
+	s.clientsMu.RLock()
+	if client, ok := s.clients[key]; ok {
+		s.clientsMu.RUnlock()
+		return client
+	}
+	s.clientsMu.RUnlock()
+
+	s.clientsMu.Lock()
+	defer s.clientsMu.Unlock()
+
+	if client, ok := s.clients[key]; ok {
+		return client
+	}
+
+	client := s.createClient(cfg)
+	s.clients[key] = client
+	return client
+}
+
+func (s *S3Storage) clientKey(cfg *BucketConfig) string {
+	return cfg.Region + "|" + cfg.Endpoint + "|" + cfg.AccessKeyID
+}
+
+func (s *S3Storage) createClient(cfg *BucketConfig) *s3.Client {
+	awsCfg := s.baseConfig
+
+	if cfg.Region != "" {
+		awsCfg.Region = cfg.Region
+	}
+
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
+		awsCfg.Credentials = credentials.NewStaticCredentialsProvider(
+			cfg.AccessKeyID, cfg.SecretAccessKey, cfg.SessionToken)
+	} else if cfg.Region != "" && cfg.Region != s.baseConfig.Region {
+		ctx := context.Background()
+		newCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.Region))
+		if err == nil {
+			awsCfg = newCfg
+		}
+	}
+
+	var s3Options []func(*s3.Options)
+
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = s.Endpoint
+	}
+	if endpoint != "" {
+		s3Options = append(s3Options, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+			o.DisableLogOutputChecksumValidationSkipped = true
+		})
+	}
+
+	if s.ForcePathStyle {
+		s3Options = append(s3Options, func(o *s3.Options) {
+			o.UsePathStyle = true
+		})
+	}
+
+	return s3.NewFromConfig(awsCfg, s3Options...)
+}
+
 func (s *S3Storage) Path(image string) (string, bool) {
 	image = "/" + imagorpath.Normalize(image, s.safeChars)
 	if !strings.HasPrefix(image, s.PathPrefix) {
@@ -91,21 +175,100 @@ func (s *S3Storage) Path(image string) (string, bool) {
 	return result, true
 }
 
-// Get implements imagor.Storage interface
 func (s *S3Storage) Get(r *http.Request, image string) (*imagor.Blob, error) {
 	ctx := r.Context()
 	image, ok := s.Path(image)
 	if !ok {
 		return nil, imagor.ErrInvalid
 	}
+
+	if s.BucketRouter == nil {
+		return s.getFromBucket(ctx, s.Client, s.Bucket, image)
+	}
+
+	cfg := s.BucketRouter.ConfigFor(image)
+	client := s.getOrCreateClient(cfg)
+	bucket := cfg.Name
+
+	fallbacks := s.BucketRouter.Fallbacks()
+	if len(fallbacks) == 0 {
+		return s.getFromBucket(ctx, client, bucket, image)
+	}
+
+	blob, err := s.getFromBucketEager(ctx, client, bucket, image)
+	if err == nil {
+		return blob, nil
+	}
+	if err != imagor.ErrNotFound {
+		return nil, err
+	}
+
+	for _, fallbackCfg := range fallbacks {
+		fallbackClient := s.getOrCreateClient(fallbackCfg)
+		blob, err = s.getFromBucketEager(ctx, fallbackClient, fallbackCfg.Name, image)
+		if err == nil {
+			return blob, nil
+		}
+		if err != imagor.ErrNotFound {
+			return nil, err
+		}
+	}
+
+	return nil, imagor.ErrNotFound
+}
+
+func (s *S3Storage) getFromBucketEager(ctx context.Context, client *s3.Client, bucket, image string) (*imagor.Blob, error) {
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(image),
+	}
+	out, err := client.GetObject(ctx, input)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, imagor.ErrNotFound
+		}
+		return nil, err
+	}
+
+	if s.Expiration > 0 && out.LastModified != nil {
+		if time.Now().Sub(*out.LastModified) > s.Expiration {
+			_ = out.Body.Close()
+			return nil, imagor.ErrExpired
+		}
+	}
+
+	var size int64
+	if out.ContentLength != nil {
+		size = *out.ContentLength
+	}
+
+	blob := imagor.NewBlob(func() (io.ReadCloser, int64, error) {
+		return out.Body, size, nil
+	})
+
+	if out.ContentType != nil {
+		blob.SetContentType(*out.ContentType)
+	}
+	if out.ContentLength != nil && out.ETag != nil && out.LastModified != nil {
+		blob.Stat = &imagor.Stat{
+			Size:         *out.ContentLength,
+			ETag:         *out.ETag,
+			ModifiedTime: *out.LastModified,
+		}
+	}
+
+	return blob, nil
+}
+
+func (s *S3Storage) getFromBucket(ctx context.Context, client *s3.Client, bucket, image string) (*imagor.Blob, error) {
 	var blob *imagor.Blob
 	var once sync.Once
 	blob = imagor.NewBlob(func() (io.ReadCloser, int64, error) {
 		input := &s3.GetObjectInput{
-			Bucket: aws.String(s.Bucket),
+			Bucket: aws.String(bucket),
 			Key:    aws.String(image),
 		}
-		out, err := s.Client.GetObject(ctx, input)
+		out, err := client.GetObject(ctx, input)
 		if err != nil {
 			if isNotFoundError(err) {
 				return nil, 0, imagor.ErrNotFound
@@ -138,7 +301,6 @@ func (s *S3Storage) Get(r *http.Request, image string) (*imagor.Blob, error) {
 	return blob, nil
 }
 
-// Put implements imagor.Storage interface
 func (s *S3Storage) Put(ctx context.Context, image string, blob *imagor.Blob) error {
 	image, ok := s.Path(image)
 	if !ok {
@@ -165,7 +327,6 @@ func (s *S3Storage) Put(ctx context.Context, image string, blob *imagor.Blob) er
 	return err
 }
 
-// Delete implements imagor.Storage interface
 func (s *S3Storage) Delete(ctx context.Context, image string) error {
 	image, ok := s.Path(image)
 	if !ok {
@@ -178,7 +339,6 @@ func (s *S3Storage) Delete(ctx context.Context, image string) error {
 	return err
 }
 
-// Stat implements imagor.Storage interface
 func (s *S3Storage) Stat(ctx context.Context, image string) (stat *imagor.Stat, err error) {
 	image, ok := s.Path(image)
 	if !ok {
@@ -202,7 +362,6 @@ func (s *S3Storage) Stat(ctx context.Context, image string) (stat *imagor.Stat, 
 	}, nil
 }
 
-// Helper function for not found errors
 func isNotFoundError(err error) bool {
 	var nsk *types.NoSuchKey
 	var nbf *types.NoSuchBucket


### PR DESCRIPTION
## Summary

Add prefix-based bucket routing for S3 loader to support multi-tenant and multi-region setups. Images can be routed to different S3 buckets based on path prefix, with each bucket supporting its own region, endpoint, and credentials.

## Motivation

In production environments with:
- **Multi-tenant architectures** — different customers' images in separate buckets
- **Multi-region deployments** — buckets distributed across regions for latency
- **Migration scenarios** — gradual migration between buckets with fallback support
- **Different storage tiers** — hot/cold storage in different buckets

The current S3 loader only supports a single bucket, requiring separate imagor instances or complex proxy setups.

## Features

### Prefix-Based Routing
Routes image requests to different buckets based on longest-prefix-first matching:
```
users/123/photo.jpg    → imagor-users bucket (eu-west-1)
products/456/image.jpg → imagor-products bucket (ap-southeast-1)
other/image.jpg        → imagor-default bucket (us-east-1)
```

### Per-Bucket Configuration
Each bucket can specify:
- `name` — S3 bucket name
- `region` — AWS region (creates region-specific client)
- `endpoint` — Custom S3 endpoint (for S3-compatible storage)
- `access_key_id` / `secret_access_key` / `session_token` — Bucket-specific credentials

### Fallback Buckets
Up to 2 fallback buckets for resilience:
- If object not found in primary bucket → try fallback buckets in order
- Useful for migrations and archive storage patterns

### YAML Configuration
```yaml
default_bucket:
  name: imagor-default
  region: us-east-1

fallback_buckets:
  - name: imagor-archive
    region: us-west-2

rules:
  - prefix: users
    bucket:
      name: imagor-users
      region: eu-west-1
  - prefix: products
    bucket:
      name: imagor-products  
      region: ap-southeast-1
      access_key_id: AKIAIOSFODNN7EXAMPLE
      secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
```

## Usage

```bash
# Via environment variable
S3_LOADER_BUCKET_ROUTER_CONFIG=/path/to/bucket-routing.yaml

# Via command line
imagor -s3-loader-bucket-router-config /path/to/bucket-routing.yaml
```

Docker Compose example:
```yaml
services:
  imagor:
    image: shumc/imagor:latest
    volumes:
      - ./bucket-routing.yaml:/etc/imagor/bucket-routing.yaml
    environment:
      S3_LOADER_BUCKET_ROUTER_CONFIG: /etc/imagor/bucket-routing.yaml
      AWS_ACCESS_KEY_ID: ...
      AWS_SECRET_ACCESS_KEY: ...
      AWS_REGION: us-east-1
```

## Implementation Details

### S3 Client Caching
- Clients are cached per unique `region|endpoint|credentials` combination
- Thread-safe with RWMutex (read-heavy workload optimized)
- Clients initialized eagerly at startup for all configured buckets

### Fallback Mechanism
- Uses `GetObject` directly (not `HeadObject`) for efficiency
- Single S3 API call per bucket attempted
- Returns immediately on first successful response
- Fallback only triggered on `NotFound` errors (other errors propagate)

### Backward Compatibility
- Existing `S3_LOADER_BUCKET` config continues to work
- If `default_bucket` not specified in YAML, falls back to `S3_LOADER_BUCKET`
- No breaking changes to existing deployments

## Files Changed

| File | Description |
|------|-------------|
| `storage/s3storage/router.go` | `BucketRouter` interface and `PrefixRouter` implementation |
| `storage/s3storage/s3storage.go` | Multi-client support, fallback logic |
| `storage/s3storage/option.go` | `WithBucketRouter` option |
| `config/awsconfig/bucket_router.go` | YAML config loader |
| `config/awsconfig/awsconfig.go` | CLI flag integration |
| `README.md` | Documentation |

## Testing

- Full unit tests for routing logic (`router_test.go`)
- YAML parsing tests (`bucket_router_test.go`)
- Existing S3 storage tests continue to pass

```bash
go test ./storage/s3storage/... -v
go test ./config/awsconfig/... -v
```