### PR TITLE
make s3 acls truly optional

### DIFF
--- a/storage/s3storage/s3storage.go
+++ b/storage/s3storage/s3storage.go
@@ -153,13 +153,15 @@ func (s *S3Storage) Put(ctx context.Context, image string, blob *imagor.Blob) er
 	}()
 
 	input := &s3.PutObjectInput{
-		ACL:           types.ObjectCannedACL(s.ACL),
 		Body:          reader,
 		Bucket:        aws.String(s.Bucket),
 		ContentType:   aws.String(blob.ContentType()),
 		ContentLength: aws.Int64(size),
 		Key:           aws.String(image),
 		StorageClass:  types.StorageClass(s.StorageClass),
+	}
+	if s.ACL != "" {
+		input.ACL = types.ObjectCannedACL(s.ACL)
 	}
 	_, err = s.Client.PutObject(ctx, input)
 	return err


### PR DESCRIPTION
To allow using a bucket that has ACLs disabled. With this change you can do

```
-s3-result-storage-acl ""
```

to avoid running into errors for put calls into buckets that have ACLs disabled.

IMO, it would be better not to apply any default ACL at all but that's an incompatible change so not my call.