### PR TITLE
fix: preserve metadata (including GIF frame delays) on export

### DIFF
--- a/processor/vipsprocessor/process.go
+++ b/processor/vipsprocessor/process.go
@@ -675,6 +675,8 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		return image.PngsaveBuffer(opts)
 	case vips.ImageTypeWebp:
@@ -683,6 +685,8 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		return image.WebpsaveBuffer(opts)
 	case vips.ImageTypeJxl:
@@ -691,6 +695,8 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		return image.JxlsaveBuffer(opts)
 	case vips.ImageTypeTiff:
@@ -699,12 +705,16 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		return image.TiffsaveBuffer(opts)
 	case vips.ImageTypeGif:
 		opts := &vips.GifsaveBufferOptions{}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		return image.GifsaveBuffer(opts)
 	case vips.ImageTypeAvif:
@@ -714,6 +724,8 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		opts.Effort = 9 - v.AvifSpeed
 		return image.HeifsaveBuffer(opts)
@@ -723,6 +735,8 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		return image.HeifsaveBuffer(opts)
 	case vips.ImageTypeJp2k:
@@ -731,6 +745,8 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else {
+			opts.Keep = vips.KeepAll
 		}
 		return image.Jp2ksaveBuffer(opts)
 	default:
@@ -749,6 +765,8 @@ func (v *Processor) export(
 		}
 		if stripMetadata {
 			opts.Keep = vips.KeepNone
+		} else if !v.MozJPEG {
+			opts.Keep = vips.KeepAll
 		}
 		return image.JpegsaveBuffer(opts)
 	}


### PR DESCRIPTION
## Summary

Fixes #735 — GIF animations processed through imagor play significantly slower than the original.

## Root Cause

The Go zero value for `vips.Keep` is `KeepNone` (`0`), which maps to `VIPS_FOREIGN_KEEP_NONE` in libvips. When export options structs are created without explicitly setting `Keep`, vipsgen passes `Keep=0` to libvips via the `WithOptions` variant, **overriding** libvips' default of `VIPS_FOREIGN_KEEP_ALL`.

This means all metadata is silently stripped on **every** export, regardless of whether `strip_metadata` is configured. The `if stripMetadata { opts.Keep = vips.KeepNone }` check is effectively a no-op since the zero value already equals `KeepNone`.

For GIFs, this strips the frame `delay` array, causing browsers to fall back to ~100ms/frame (10fps) — making animations visibly slower.

## Fix

Explicitly set `opts.Keep = vips.KeepAll` in the `else` branch for all export formats, so metadata is preserved when `strip_metadata` is not requested.

For JPEG with MozJPEG enabled, the existing `KeepNone` behavior is preserved (MozJPEG intentionally strips metadata for maximum compression).

## Affected Formats

All formats in the `export()` function: PNG, WebP, JXL, TIFF, GIF, AVIF, HEIF, JP2K, JPEG.