### PR TITLE
feat: add in-memory watermark cache with ristretto

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,16 @@ VIPS_MAX_WIDTH=5000
 VIPS_MAX_HEIGHT=5000
 ```
 
+#### Watermark Cache
+
+imagor provides an optional in-memory cache for watermark images to avoid repeated loading and processing. This is particularly useful when the same watermark is applied to many images.
+
+```dotenv
+IMAGOR_WATERMARK_CACHE_SIZE=104857600  # 100MB watermark cache
+```
+
+The cache stores thumbnailed watermark images as `vips.Image` objects for fast retrieval via copy-on-write. Cache cost is based on pixel dimensions (`width × height × bands`). Cached entries are keyed by image path and thumbnail dimensions, so the same watermark at the same size is loaded only once regardless of alpha or position parameters.
+
 #### Allowed Sources and Base URL
 
 Whitelist specific hosts to restrict loading images only from the allowed sources using `HTTP_LOADER_ALLOWED_SOURCES` or `HTTP_LOADER_ALLOWED_SOURCE_REGEXP`.
@@ -1115,6 +1125,8 @@ Usage of imagor:
         VIPS strips all metadata from the resulting image
   -vips-unlimited
     	VIPS bypass image max resolution check and remove all denial of service limits
+  -imagor-watermark-cache-size int64
+        In-memory watermark cache size in bytes (0 to disable). e.g. 104857600 for 100MB (default 0)
         
   -sentry-dsn
         include sentry dsn to integrate imagor with sentry

--- a/config/vipsconfig/vipsconfig.go
+++ b/config/vipsconfig/vipsconfig.go
@@ -41,6 +41,8 @@ func WithVips(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			"VIPS strips all metadata from the resulting image")
 		vipsUnlimited = fs.Bool("vips-unlimited", false,
 			"VIPS bypass image max resolution check and remove all denial of service limits")
+		imagorWatermarkCacheSize = fs.Int64("imagor-watermark-cache-size", 0,
+			"In-memory watermark cache size in bytes (0 to disable). e.g. 104857600 for 100MB")
 
 		logger, isDebug = cb()
 	)
@@ -61,6 +63,7 @@ func WithVips(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 			vipsprocessor.WithAvifSpeed(*vipsAvifSpeed),
 			vipsprocessor.WithStripMetadata(*vipsStripMetadata),
 			vipsprocessor.WithUnlimited(*vipsUnlimited),
+			vipsprocessor.WithWatermarkCacheSize(*imagorWatermarkCacheSize),
 			vipsprocessor.WithLogger(logger),
 			vipsprocessor.WithDebug(isDebug),
 		),

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.4
 	github.com/aws/smithy-go v1.24.2
 	github.com/cshum/vipsgen v1.3.8
+	github.com/dgraph-io/ristretto v0.1.1
 	github.com/fsouza/fake-gcs-server v1.54.0
 	github.com/getsentry/sentry-go v0.43.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20260208201424-4c385a1f6a73
@@ -56,12 +57,14 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/glog v1.2.5 // indirect
 	github.com/google/renameio/v2 v2.0.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqx
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cevatbarisyilmaz/ara v0.0.4 h1:SGH10hXpBJhhTlObuZzTuFn1rrdmjQImITXnZVPSodc=
@@ -91,6 +92,11 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
+github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -123,6 +129,8 @@ github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
+github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -224,6 +232,7 @@ github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xI
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -302,6 +311,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -356,6 +366,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce h1:xcEWjVhvbDy+nHP67nPDDpbYrY+ILlfndk4bRioVHaU=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/processor/vipsprocessor/filter.go
+++ b/processor/vipsprocessor/filter.go
@@ -86,13 +86,10 @@ func (v *Processor) watermark(ctx context.Context, img *vips.Image, load imagor.
 		}
 	}
 
-	var blob *imagor.Blob
-	if blob, err = load(image); err != nil {
-		return
-	}
 	var w, h int
 	var overlay *vips.Image
 	var n = 1
+	var size = vips.SizeDown
 	if isAnimated(img) {
 		n = -1
 	}
@@ -108,16 +105,39 @@ func (v *Processor) watermark(ctx context.Context, img *vips.Image, load imagor.
 			h, _ = strconv.Atoi(args[5])
 			h = img.PageHeight() * h / 100
 		}
+		size = vips.SizeBoth
+	} else {
+		w = v.MaxWidth
+		h = v.MaxHeight
+	}
+
+	// try watermark cache
+	var cached bool
+	cacheKey := fmt.Sprintf("wm:%s:%d:%d:%d:%d", image, w, h, n, size)
+	if v.watermarkCache != nil {
+		if val, ok := v.watermarkCache.Get(cacheKey); ok {
+			if cachedImg, ok := val.(*vips.Image); ok {
+				if overlay, err = cachedImg.Copy(nil); err == nil {
+					cached = true
+				}
+			}
+		}
+	}
+	if !cached {
+		var blob *imagor.Blob
+		if blob, err = load(image); err != nil {
+			return
+		}
 		if overlay, err = v.NewThumbnail(
-			ctx, blob, w, h, vips.InterestingNone, vips.SizeBoth, n, 1, 0,
+			ctx, blob, w, h, vips.InterestingNone, size, n, 1, 0,
 		); err != nil {
 			return
 		}
-	} else {
-		if overlay, err = v.NewThumbnail(
-			ctx, blob, v.MaxWidth, v.MaxHeight, vips.InterestingNone, vips.SizeDown, n, 1, 0,
-		); err != nil {
-			return
+		if v.watermarkCache != nil {
+			if cachedImg, copyErr := overlay.Copy(nil); copyErr == nil {
+				cost := int64(cachedImg.Width() * cachedImg.Height() * cachedImg.Bands())
+				v.watermarkCache.Set(cacheKey, cachedImg, cost)
+			}
 		}
 	}
 	contextDefer(ctx, overlay.Close)

--- a/processor/vipsprocessor/option.go
+++ b/processor/vipsprocessor/option.go
@@ -171,3 +171,12 @@ func WithUnlimited(unlimited bool) Option {
 		v.Unlimited = unlimited
 	}
 }
+
+// WithWatermarkCacheSize with watermark cache max size in bytes
+func WithWatermarkCacheSize(size int64) Option {
+	return func(v *Processor) {
+		if size > 0 {
+			v.WatermarkCacheSize = size
+		}
+	}
+}

--- a/processor/vipsprocessor/option_test.go
+++ b/processor/vipsprocessor/option_test.go
@@ -29,6 +29,7 @@ func TestWithOption(t *testing.T) {
 			WithDisableFilters("rgb", "fill, watermark"),
 			WithUnlimited(true),
 			WithForceBmpFallback(),
+			WithWatermarkCacheSize(104857600),
 			WithFilter("noop", func(ctx context.Context, img *vips.Image, load imagor.LoadFunc, args ...string) (err error) {
 				return nil
 			}),
@@ -47,6 +48,7 @@ func TestWithOption(t *testing.T) {
 		assert.Equal(t, true, v.Unlimited)
 		assert.Equal(t, 9, v.AvifSpeed)
 		assert.Equal(t, []string{"rgb", "fill", "watermark"}, v.DisableFilters)
+		assert.Equal(t, int64(104857600), v.WatermarkCacheSize)
 		assert.NotNil(t, v.FallbackFunc)
 
 	})

--- a/processor/vipsprocessor/processor.go
+++ b/processor/vipsprocessor/processor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cshum/imagor"
 	"github.com/cshum/vipsgen/vips"
+	"github.com/dgraph-io/ristretto"
 	"go.uber.org/zap"
 )
 
@@ -42,8 +43,10 @@ type Processor struct {
 	AvifSpeed          int
 	Unlimited          bool
 	Debug              bool
+	WatermarkCacheSize int64
 
 	disableFilters map[string]bool
+	watermarkCache *ristretto.Cache
 }
 
 // NewProcessor create Processor
@@ -136,6 +139,24 @@ func (v *Processor) Startup(_ context.Context) error {
 			v.Logger.Debug("source fallback", zap.String("fallback", "bmp"))
 		}
 	}
+	if v.WatermarkCacheSize > 0 {
+		cache, err := ristretto.NewCache(&ristretto.Config{
+			NumCounters: 1e4,
+			MaxCost:     v.WatermarkCacheSize,
+			BufferItems: 64,
+			OnEvict: func(item *ristretto.Item) {
+				if img, ok := item.Value.(*vips.Image); ok {
+					img.Close()
+				}
+			},
+		})
+		if err != nil {
+			return err
+		}
+		v.watermarkCache = cache
+		v.Logger.Debug("watermark cache enabled",
+			zap.Int64("max_size", v.WatermarkCacheSize))
+	}
 	return nil
 }
 
@@ -143,6 +164,9 @@ func (v *Processor) Startup(_ context.Context) error {
 func (v *Processor) Shutdown(_ context.Context) error {
 	processorLock.Lock()
 	defer processorLock.Unlock()
+	if v.watermarkCache != nil {
+		v.watermarkCache.Close()
+	}
 	if processorCount <= 0 {
 		return nil
 	}

--- a/processor/vipsprocessor/processor_test.go
+++ b/processor/vipsprocessor/processor_test.go
@@ -565,6 +565,77 @@ func TestProcessor(t *testing.T) {
 		assert.Empty(t, img)
 		assert.Error(t, err)
 	})
+	t.Run("watermark cache", func(t *testing.T) {
+		loadCount := 0
+		loader := loaderFunc(func(r *http.Request, image string) (blob *imagor.Blob, err error) {
+			loadCount++
+			return imagor.NewBlobFromFile(filepath.Join(testDataDir, image)), nil
+		})
+		app := imagor.New(
+			imagor.WithLoaders(loader),
+			imagor.WithUnsafe(true),
+			imagor.WithDebug(true),
+			imagor.WithLogger(zap.NewExample()),
+			imagor.WithProcessors(NewProcessor(
+				WithDebug(true),
+				WithWatermarkCacheSize(10*1024*1024),
+			)),
+		)
+		require.NoError(t, app.Startup(context.Background()))
+		t.Cleanup(func() {
+			assert.NoError(t, app.Shutdown(context.Background()))
+		})
+
+		w := httptest.NewRecorder()
+		app.ServeHTTP(w, httptest.NewRequest(
+			http.MethodGet, "/unsafe/fit-in/200x200/filters:watermark(gopher-front.png,center,center,50,20,20)/demo1.jpg", nil))
+		assert.Equal(t, 200, w.Code)
+		firstLoadCount := loadCount
+
+		time.Sleep(100 * time.Millisecond)
+
+		w = httptest.NewRecorder()
+		app.ServeHTTP(w, httptest.NewRequest(
+			http.MethodGet, "/unsafe/fit-in/300x300/filters:watermark(gopher-front.png,center,center,50,20,20)/demo2.jpg", nil))
+		assert.Equal(t, 200, w.Code)
+
+		assert.Equal(t, firstLoadCount+1, loadCount,
+			"watermark should be served from cache, only base image should be loaded")
+	})
+	t.Run("watermark cache disabled", func(t *testing.T) {
+		loadCount := 0
+		loader := loaderFunc(func(r *http.Request, image string) (blob *imagor.Blob, err error) {
+			loadCount++
+			return imagor.NewBlobFromFile(filepath.Join(testDataDir, image)), nil
+		})
+		app := imagor.New(
+			imagor.WithLoaders(loader),
+			imagor.WithUnsafe(true),
+			imagor.WithDebug(true),
+			imagor.WithLogger(zap.NewExample()),
+			imagor.WithProcessors(NewProcessor(
+				WithDebug(true),
+			)),
+		)
+		require.NoError(t, app.Startup(context.Background()))
+		t.Cleanup(func() {
+			assert.NoError(t, app.Shutdown(context.Background()))
+		})
+
+		w := httptest.NewRecorder()
+		app.ServeHTTP(w, httptest.NewRequest(
+			http.MethodGet, "/unsafe/fit-in/200x200/filters:watermark(gopher-front.png,center,center,50,20,20)/demo1.jpg", nil))
+		assert.Equal(t, 200, w.Code)
+		firstLoadCount := loadCount
+
+		w = httptest.NewRecorder()
+		app.ServeHTTP(w, httptest.NewRequest(
+			http.MethodGet, "/unsafe/fit-in/300x300/filters:watermark(gopher-front.png,center,center,50,20,20)/demo2.jpg", nil))
+		assert.Equal(t, 200, w.Code)
+
+		assert.Equal(t, firstLoadCount+2, loadCount,
+			"without cache, both base image and watermark should be loaded")
+	})
 }
 
 func doGoldenTests(t *testing.T, resultDir string, tests []test, opts ...Option) {


### PR DESCRIPTION
## Summary

Adds an optional in-memory cache for thumbnailed watermark images using [dgraph-io/ristretto](https://github.com/dgraph-io/ristretto), eliminating repeated loading and processing of the same watermark across requests.

- **Cache layer**: Sits between `NewThumbnail` and `compositeOverlay` — caches the expensive load+decode+thumbnail, while `compositeOverlay` handles colorspace, alpha, and positioning on each use
- **Cache key**: image path + thumbnail dimensions + animation flag + size mode (alpha excluded for higher hit rates)
- **Memory managed**: Ristretto's size-aware eviction with `OnEvict` callback to `Close()` evicted `vips.Image` objects
- **Opt-in**: Disabled by default, enabled via `-imagor-watermark-cache-size` (bytes)

### Changes from previous PR (#713)

This is a clean rewrite on latest master addressing architectural concerns:

1. **Removed singleflight from `imagor.go`** — the previous PR added singleflight to the core `load` function for ALL images. This was scope creep; `app.suppress` already deduplicates at the request level
2. **No duplication of `compositeOverlay` logic** — the previous PR pre-applied colorspace conversion, alpha channel, and alpha transparency inside the watermark filter, then passed `alpha=0` to `compositeOverlay`. This duplicated overlay.go's rendering pipeline. Now the cache stores the raw thumbnail and lets `compositeOverlay` handle all rendering
3. **Alpha excluded from cache key** — same watermark at same size with different alpha values shares one cache entry (higher hit rate)
4. **No logging in filter functions** — removed `zap` import from filter.go to match existing convention (no filters use logging)
5. **Collapsed duplicate NewThumbnail branches** — the two `NewThumbnail` calls (SizeBoth vs SizeDown) are unified with a `size` variable

### Configuration

```bash
# Enable watermark cache with 100MB limit
IMAGOR_WATERMARK_CACHE_SIZE=104857600

# Or via command line
imagor -imagor-watermark-cache-size 104857600
```
