### PR TITLE
fix(s3): wire per-bucket endpoint and credentials from router config

### DIFF
--- a/config/awsconfig/awsconfig.go
+++ b/config/awsconfig/awsconfig.go
@@ -199,14 +199,16 @@ func WithAWS(fs *flag.FlagSet, cb func() (*zap.Logger, bool)) imagor.Option {
 				endpoint = *s3Endpoint
 			}
 
-			storageFactory := func(cfg aws.Config, bucket string) *s3storage.S3Storage {
-				return s3storage.New(cfg, bucket,
+			storageFactory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
+				opts := []s3storage.Option{
 					s3storage.WithPathPrefix(*s3LoaderPathPrefix),
 					s3storage.WithBaseDir(*s3LoaderBaseDir),
 					s3storage.WithSafeChars(*s3SafeChars),
 					s3storage.WithEndpoint(endpoint),
 					s3storage.WithForcePathStyle(*s3ForcePathStyle),
-				)
+				}
+				opts = append(opts, extraOpts...)
+				return s3storage.New(cfg, bucket, opts...)
 			}
 
 			loader := s3routerloader.New(loaderCfg, router, storageFactory)

--- a/loader/s3routerloader/s3routerloader.go
+++ b/loader/s3routerloader/s3routerloader.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/cshum/imagor"
 	"github.com/cshum/imagor/storage/s3storage"
 )
@@ -18,7 +19,7 @@ type S3RouterLoader struct {
 	dynamicLoaders sync.Map // bucket name → *s3storage.S3Storage, for passthrough mode
 }
 
-type S3StorageFactory func(cfg aws.Config, bucket string) *s3storage.S3Storage
+type S3StorageFactory func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage
 
 func New(
 	baseCfg aws.Config,
@@ -34,7 +35,11 @@ func New(
 
 	for _, bucketCfg := range router.AllConfigs() {
 		awsCfg := createAWSConfig(baseCfg, bucketCfg)
-		l.loaders[bucketCfg.Name] = storageFactory(awsCfg, bucketCfg.Name)
+		var extraOpts []s3storage.Option
+		if bucketCfg.Endpoint != "" {
+			extraOpts = append(extraOpts, s3storage.WithEndpoint(bucketCfg.Endpoint))
+		}
+		l.loaders[bucketCfg.Name] = storageFactory(awsCfg, bucketCfg.Name, extraOpts...)
 	}
 
 	for _, fb := range router.Fallbacks() {
@@ -51,6 +56,14 @@ func createAWSConfig(baseCfg aws.Config, bucketCfg *BucketConfig) aws.Config {
 
 	if bucketCfg.Region != "" {
 		cfg.Region = bucketCfg.Region
+	}
+
+	if bucketCfg.AccessKeyID != "" && bucketCfg.SecretAccessKey != "" {
+		cfg.Credentials = credentials.NewStaticCredentialsProvider(
+			bucketCfg.AccessKeyID,
+			bucketCfg.SecretAccessKey,
+			bucketCfg.SessionToken,
+		)
 	}
 
 	return cfg

--- a/loader/s3routerloader/s3routerloader_test.go
+++ b/loader/s3routerloader/s3routerloader_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/cshum/imagor/storage/s3storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,7 @@ func TestS3RouterLoader_RoutesToCorrectBucket(t *testing.T) {
 	require.NoError(t, err)
 
 	createdBuckets := make(map[string]bool)
-	factory := func(cfg aws.Config, bucket string) *s3storage.S3Storage {
+	factory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
 		createdBuckets[bucket] = true
 		return s3storage.New(cfg, bucket)
 	}
@@ -48,7 +49,7 @@ func TestS3RouterLoader_Get_NoMatchingLoader(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	factory := func(cfg aws.Config, bucket string) *s3storage.S3Storage {
+	factory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
 		return s3storage.New(cfg, bucket)
 	}
 
@@ -77,7 +78,7 @@ func TestS3RouterLoader_Get_UsesKeyForWithPathGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	receivedKeys := make(map[string]string) // bucket -> key
-	factory := func(cfg aws.Config, bucket string) *s3storage.S3Storage {
+	factory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
 		return s3storage.New(cfg, bucket)
 	}
 
@@ -110,7 +111,7 @@ func TestS3RouterLoader_PassthroughMode(t *testing.T) {
 	require.NoError(t, err)
 
 	createdBuckets := make(map[string]bool)
-	factory := func(cfg aws.Config, bucket string) *s3storage.S3Storage {
+	factory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
 		createdBuckets[bucket] = true
 		return s3storage.New(cfg, bucket)
 	}
@@ -162,7 +163,7 @@ func TestS3RouterLoader_CreatesClientsForAllConfigs(t *testing.T) {
 	require.NoError(t, err)
 
 	regions := make(map[string]string)
-	factory := func(cfg aws.Config, bucket string) *s3storage.S3Storage {
+	factory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
 		regions[bucket] = cfg.Region
 		return s3storage.New(cfg, bucket)
 	}
@@ -172,4 +173,73 @@ func TestS3RouterLoader_CreatesClientsForAllConfigs(t *testing.T) {
 	assert.Equal(t, "us-east-1", regions["default"])
 	assert.Equal(t, "ap-southeast-1", regions["sg"])
 	assert.Equal(t, "eu-west-1", regions["fallback"])
+}
+
+func TestS3RouterLoader_PerBucketEndpoint(t *testing.T) {
+	bucket1 := &BucketConfig{Name: "bucket1", Endpoint: "http://minio1:9000"}
+	bucket2 := &BucketConfig{Name: "bucket2"}
+
+	router, err := NewPatternRouter(
+		`^(?P<bucket>[^/]+)\/(?P<path>.+)$`,
+		[]MatchRule{
+			{Match: "bucket1", Config: bucket1},
+			{Match: "bucket2", Config: bucket2},
+		},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	endpoints := make(map[string]string)
+	factory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
+		s := s3storage.New(cfg, bucket, extraOpts...)
+		endpoints[bucket] = s.Endpoint
+		return s
+	}
+
+	_ = New(aws.Config{Region: "us-east-1"}, router, factory)
+
+	assert.Equal(t, "http://minio1:9000", endpoints["bucket1"])
+	assert.Equal(t, "", endpoints["bucket2"])
+}
+
+func TestS3RouterLoader_PerBucketCredentials(t *testing.T) {
+	bucket1 := &BucketConfig{
+		Name:            "bucket1",
+		AccessKeyID:     "bucket1-key",
+		SecretAccessKey: "bucket1-secret",
+	}
+	bucket2 := &BucketConfig{
+		Name: "bucket2",
+	}
+
+	router, err := NewPatternRouter(
+		`^(?P<bucket>[^/]+)\/(?P<path>.+)$`,
+		[]MatchRule{
+			{Match: "bucket1", Config: bucket1},
+			{Match: "bucket2", Config: bucket2},
+		},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	configs := make(map[string]aws.Config)
+	factory := func(cfg aws.Config, bucket string, extraOpts ...s3storage.Option) *s3storage.S3Storage {
+		configs[bucket] = cfg
+		return s3storage.New(cfg, bucket, extraOpts...)
+	}
+
+	globalCreds := credentials.NewStaticCredentialsProvider("global-key", "global-secret", "")
+	_ = New(aws.Config{Region: "us-east-1", Credentials: globalCreds}, router, factory)
+
+	creds1, err := configs["bucket1"].Credentials.Retrieve(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "bucket1-key", creds1.AccessKeyID)
+	assert.Equal(t, "bucket1-secret", creds1.SecretAccessKey)
+
+	creds2, err := configs["bucket2"].Credentials.Retrieve(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "global-key", creds2.AccessKeyID)
+	assert.Equal(t, "global-secret", creds2.SecretAccessKey)
 }


### PR DESCRIPTION
## Summary

Per-bucket `endpoint` and `credentials` from the S3 bucket routing YAML config are documented but not applied. This PR wires them through so they actually work.

## Problem

The [S3 Loader Bucket Routing docs](https://github.com/cshum/imagor/blob/master/docs/docs/storage-s3.md#s3-loader-bucket-routing) state:

> Each bucket config can specify its own `region`, `endpoint`, and credentials

And the YAML example shows per-bucket `endpoint`, `access_key_id`, and `secret_access_key`. However, `createAWSConfig` in `s3routerloader.go` only applied `Region` from `BucketConfig` — `Endpoint`, `AccessKeyID`, `SecretAccessKey`, and `SessionToken` were silently ignored. Every bucket used the shared loader endpoint (`--s3-loader-endpoint` / `--s3-endpoint`) and shared loader credentials regardless of what the YAML specified.

This means multi-endpoint setups (e.g. buckets on different S3-compatible servers like separate MinIO instances) didn't work through the router config.

## Fix

- `createAWSConfig` now applies `AccessKeyID`/`SecretAccessKey`/`SessionToken` from `BucketConfig` when present, falling back to shared loader credentials otherwise
- `New()` passes `s3storage.WithEndpoint()` as an extra option to the factory when a bucket has a custom endpoint
- `S3StorageFactory` signature gains `extraOpts ...s3storage.Option` to support this

The factory signature change is technically a breaking change on an exported type. In practice, the only caller is `awsconfig.go` within imagor itself. Callers that don't pass extra options still compile and work as before.

## Testing

Added two tests:
- `TestS3RouterLoader_PerBucketEndpoint` — verifies per-bucket endpoint is applied, and buckets without a custom endpoint use the factory default
- `TestS3RouterLoader_PerBucketCredentials` — verifies per-bucket credentials override global, and buckets without credentials fall back to global

All existing tests pass.
