### PR TITLE
Add configurable Prometheus metrics namespace

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -164,8 +164,9 @@ func CreateServer(args []string, funcs ...Option) (srv *server.Server) {
 		sentryDsn = fs.String("sentry-dsn", "",
 			"Sentry DSN config")
 
-		prometheusBind = fs.String("prometheus-bind", "", "Specify address and port to enable Prometheus metrics, e.g. :5000, prom:7000")
-		prometheusPath = fs.String("prometheus-path", "/", "Prometheus metrics path")
+		prometheusBind      = fs.String("prometheus-bind", "", "Specify address and port to enable Prometheus metrics, e.g. :5000, prom:7000")
+		prometheusPath      = fs.String("prometheus-path", "/", "Prometheus metrics path")
+		prometheusNamespace = fs.String("prometheus-namespace", prometheusmetrics.DefaultNamespace, "Prometheus metrics namespace")
 	)
 
 	app = NewImagor(fs, func() (*zap.Logger, bool) {
@@ -226,6 +227,7 @@ func CreateServer(args []string, funcs ...Option) (srv *server.Server) {
 		pm = prometheusmetrics.New(
 			prometheusmetrics.WithAddr(*prometheusBind),
 			prometheusmetrics.WithPath(*prometheusPath),
+			prometheusmetrics.WithNamespace(*prometheusNamespace),
 			prometheusmetrics.WithLogger(logger),
 		)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -210,11 +210,13 @@ func TestPrometheusBind(t *testing.T) {
 		"-bind", ":2345",
 		"-prometheus-bind", ":6789",
 		"-prometheus-path", "/myprom",
+		"-prometheus-namespace", "custom",
 	})
 	assert.Equal(t, ":2345", srv.Addr)
 	pm := srv.Metrics.(*prometheusmetrics.PrometheusMetrics)
-	assert.Equal(t, pm.Path, "/myprom")
-	assert.Equal(t, pm.Addr, ":6789")
+	assert.Equal(t, "/myprom", pm.Path)
+	assert.Equal(t, "custom", pm.Namespace)
+	assert.Equal(t, ":6789", pm.Addr)
 }
 
 func TestUploadLoader(t *testing.T) {

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -267,6 +267,7 @@ VIPS_CACHE_FORMAT=pixel      # Cache format: pixel (default), png (lossless), we
 # Prometheus metrics
 PROMETHEUS_BIND=:5000        # Address to expose Prometheus metrics. Disabled if not set
 PROMETHEUS_PATH=/            # Metrics path (default /)
+PROMETHEUS_NAMESPACE=imagor  # Metrics namespace (default imagor)
 
 # Sentry error tracking
 SENTRY_DSN=                  # Sentry DSN. Enables Sentry integration when set

--- a/metrics/prometheusmetrics/prometheus.go
+++ b/metrics/prometheusmetrics/prometheus.go
@@ -9,29 +9,25 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	httpRequestDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "http_request_duration_seconds",
-			Help: "A histogram of latencies for requests",
-		},
-		[]string{"code", "method"},
-	)
-)
+const DefaultNamespace = "imagor"
+
+var httpRequestDuration *prometheus.HistogramVec
 
 // PrometheusMetrics wraps the Service with additional http and app lifecycle handling
 type PrometheusMetrics struct {
 	http.Server
 
-	Path   string
-	Logger *zap.Logger
+	Path      string
+	Namespace string
+	Logger    *zap.Logger
 }
 
 // New create new metrics PrometheusMetrics
 func New(options ...Option) *PrometheusMetrics {
 	s := &PrometheusMetrics{
-		Path:   "/",
-		Logger: zap.NewNop(),
+		Path:      "/",
+		Namespace: DefaultNamespace,
+		Logger:    zap.NewNop(),
 	}
 	for _, option := range options {
 		option(s)
@@ -46,7 +42,21 @@ func New(options ...Option) *PrometheusMetrics {
 	} else {
 		s.Handler = promhttp.Handler()
 	}
+
+	s.prepareMetrics()
+
 	return s
+}
+
+func (s *PrometheusMetrics) prepareMetrics() {
+	httpRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: s.Namespace,
+			Name:      "http_request_duration_seconds",
+			Help:      "A histogram of latencies for requests",
+		},
+		[]string{"code", "method"},
+	)
 }
 
 // Startup prometheus metrics server
@@ -83,6 +93,13 @@ func WithAddr(addr string) Option {
 func WithPath(path string) Option {
 	return func(s *PrometheusMetrics) {
 		s.Path = path
+	}
+}
+
+// WithNamespace with namespace option
+func WithNamespace(namespace string) Option {
+	return func(s *PrometheusMetrics) {
+		s.Namespace = namespace
 	}
 }
 

--- a/metrics/prometheusmetrics/prometheus_test.go
+++ b/metrics/prometheusmetrics/prometheus_test.go
@@ -21,6 +21,7 @@ func TestWithOption(t *testing.T) {
 		v := New()
 		assert.Empty(t, v.Addr)
 		assert.Equal(t, v.Path, "/")
+		assert.Equal(t, DefaultNamespace, v.Namespace)
 		assert.NotNil(t, v.Logger)
 	})
 
@@ -29,9 +30,11 @@ func TestWithOption(t *testing.T) {
 		v := New(
 			WithAddr("domain.example.com:1111"),
 			WithPath("/myprom"),
+			WithNamespace("custom"),
 			WithLogger(l),
 		)
 		assert.Equal(t, "/myprom", v.Path)
+		assert.Equal(t, "custom", v.Namespace)
 		assert.Equal(t, "domain.example.com:1111", v.Addr)
 		assert.Equal(t, &l, &v.Logger)
 		w := httptest.NewRecorder()
@@ -170,7 +173,7 @@ func TestHandle(t *testing.T) {
 	defer func() { prometheus.DefaultRegisterer = originalRegisterer }()
 
 	v := New()
-	
+
 	// Create a test handler
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -189,9 +192,9 @@ func TestHandle(t *testing.T) {
 	t.Run("middleware wraps handler", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
-		
+
 		wrappedHandler.ServeHTTP(w, r)
-		
+
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "test response", w.Body.String())
 	})
@@ -199,17 +202,54 @@ func TestHandle(t *testing.T) {
 	t.Run("metrics are collected", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/api/test", nil)
-		
+
 		wrappedHandler.ServeHTTP(w, r)
-		
+
 		// Check that the wrapped handler still works correctly
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "test response", w.Body.String())
-		
+
 		// The metrics collection is tested by the fact that the middleware
 		// wraps the handler without errors and prometheus instrumentation
 		// is applied (verified by the successful startup and handler wrapping)
 	})
+}
+
+func TestWithNamespaceMetricName(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	originalRegisterer := prometheus.DefaultRegisterer
+	prometheus.DefaultRegisterer = registry
+	defer func() { prometheus.DefaultRegisterer = originalRegisterer }()
+
+	v := New(
+		WithAddr(":0"),
+		WithNamespace("custom"),
+	)
+
+	ctx := context.Background()
+	err := v.Startup(ctx)
+	require.NoError(t, err)
+	defer v.Close()
+
+	wrappedHandler := v.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	wrappedHandler.ServeHTTP(w, r)
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	found := false
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() == "custom_http_request_duration_seconds" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected namespaced HTTP request duration metric")
 }
 
 func TestPrometheusMetricsIntegration(t *testing.T) {
@@ -239,7 +279,7 @@ func TestPrometheusMetricsIntegration(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 		v.Handler.ServeHTTP(w, r)
-		
+
 		assert.Equal(t, http.StatusOK, w.Code)
 		// Check that we get prometheus metrics output (the specific metric may not be visible
 		// until requests are made through the instrumented handler)
@@ -249,7 +289,7 @@ func TestPrometheusMetricsIntegration(t *testing.T) {
 		w = httptest.NewRecorder()
 		r = httptest.NewRequest(http.MethodGet, "/", nil)
 		v.Handler.ServeHTTP(w, r)
-		
+
 		assert.Equal(t, http.StatusPermanentRedirect, w.Code)
 		assert.Equal(t, "/metrics", w.Header().Get("Location"))
 
@@ -257,8 +297,8 @@ func TestPrometheusMetricsIntegration(t *testing.T) {
 		logEntries := logs.All()
 		found := false
 		for _, entry := range logEntries {
-			if entry.Message == "prometheus listen" && 
-			   strings.Contains(entry.ContextMap()["path"].(string), "/metrics") {
+			if entry.Message == "prometheus listen" &&
+				strings.Contains(entry.ContextMap()["path"].(string), "/metrics") {
 				found = true
 				break
 			}
@@ -292,4 +332,10 @@ func TestWithPath(t *testing.T) {
 	path := "/custom-metrics"
 	v := New(WithPath(path))
 	assert.Equal(t, path, v.Path)
+}
+
+func TestWithNamespace(t *testing.T) {
+	namespace := "custom"
+	v := New(WithNamespace(namespace))
+	assert.Equal(t, namespace, v.Namespace)
 }


### PR DESCRIPTION
## Summary

- Add a default Prometheus metrics namespace of `imagor`
- Add `WithNamespace` for configuring the Prometheus histogram namespace
- Wire namespace config through `-prometheus-namespace` / `PROMETHEUS_NAMESPACE`
- Document the new `PROMETHEUS_NAMESPACE` setting
- Add tests for namespace config and emitted metric name

## Notes

The HTTP request duration metric is now exposed as:

- `imagor_http_request_duration_seconds` by default
- `<namespace>_http_request_duration_seconds` when configured