### PR TITLE
fix: always send Vary: Accept when auto format negotiation applies

### DIFF
--- a/imagor.go
+++ b/imagor.go
@@ -339,6 +339,12 @@ func (app *Imagor) Do(r *http.Request, p imagorpath.Params) (blob *Blob, err err
 	// auto WebP / AVIF / JPEG
 	if !hasFormat && (app.AutoWebP || app.AutoAVIF || app.AutoJPEG) {
 		accept := r.Header.Get("Accept")
+		// The selected representation depends on Accept even when negotiation ends up
+		// keeping the source format (e.g. Accept: */* with only auto-avif/webp on).
+		// Mark it upfront so such responses still carry Vary: Accept - without it a
+		// shared cache may reuse the source-format response for clients that would
+		// have been served AVIF/WebP.
+		r.Header.Set("Imagor-Auto-Format", "none")
 		if app.AutoAVIF && strings.Contains(accept, "image/avif") {
 			p.Filters = append(p.Filters, imagorpath.Filter{
 				Name: "format",

--- a/imagor_test.go
+++ b/imagor_test.go
@@ -1433,6 +1433,21 @@ func TestAutoWebP(t *testing.T) {
 		r.Header.Set("Accept", "image/apng,image/svg+xml,image/*,*/*;q=0.8")
 		app.ServeHTTP(w, r)
 		assert.Equal(t, 200, w.Code)
+		// Source format was selected by looking at Accept: the response still varies
+		// on it, otherwise a shared cache would reuse this for WebP-capable clients.
+		assert.Equal(t, "Accept", w.Header().Get("Vary"))
+		assert.Equal(t, w.Body.String(), "abc.png")
+	})
+	t.Run("no auto no vary", func(t *testing.T) {
+		app := factory(false)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(
+			http.MethodGet, "https://example.com/unsafe/abc.png", nil)
+		r.Header.Set("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8")
+		app.ServeHTTP(w, r)
+		assert.Equal(t, 200, w.Code)
+		// Auto format off: Accept is never looked at, so no Vary.
+		assert.Empty(t, w.Header().Get("Vary"))
 		assert.Equal(t, w.Body.String(), "abc.png")
 	})
 	t.Run("explicit format no auto", func(t *testing.T) {


### PR DESCRIPTION
## The problem

When `AutoWebP` / `AutoAVIF` / `AutoJPEG` is enabled, imagor inspects the `Accept` header to choose the output format. But `Vary: Accept` is only added when the negotiation **changed** the format — it's gated on the internal `Imagor-Auto-Format` marker, which is only set inside the matching branch ([`imagor.go#L890`](https://github.com/cshum/imagor/blob/master/imagor.go#L890)).

So a client that accepts none of the auto formats gets the **source format back with no `Vary` header at all**. With `IMAGOR_AUTO_AVIF=1 IMAGOR_AUTO_WEBP=1` (auto-jpeg off, because it flattens alpha on transparent PNGs):

| `Accept` | response | `Vary` |
| :--- | :--- | :--- |
| `image/avif,image/webp,*/*` (Chrome) | AVIF | `Accept` |
| `image/webp,*/*` (Safari 15) | WebP | `Accept` |
| `*/*` (curl, crawler) | PNG | **missing** ❌ |
| `image/*` (email client) | PNG | **missing** ❌ |

## Why it matters

That last response is cacheable for *every* client. We run imagor behind Cloudflare, which honours `Vary` — so a single `curl`, uptime check or older crawler warming a cold URL can pin that image to its source format **for all subsequent visitors**, Chrome included, for as long as the CDN keeps it. The AVIF we configured is silently never served for that URL.

Nothing breaks visually (PNG/JPEG are universally supported), so it fails quietly — which is what makes it easy to miss.

## Why `Vary` belongs there anyway

Per [RFC 9110 §12.5.5](https://www.rfc-editor.org/rfc/rfc9110#name-vary), `Vary` describes the request headers the server **consulted** to select the representation, not whether the outcome differed from the default. Here `Accept` *is* consulted: had it been different, a different representation would have been sent. So the response varies on `Accept` regardless of which branch was taken.

## The fix

Mark negotiation as soon as the auto-format block is entered, instead of only inside each matching branch. Two lines plus a comment.

Requests with an explicit `filters:format(...)` never look at `Accept` (`hasFormat` short-circuits the block) and correctly keep **no** `Vary` — unchanged.

## Tests

- `TestAutoWebP/no_supported_no_auto` (existing case, previously asserted only the body) now asserts `Vary: Accept`. It **fails without the fix** and passes with it.
- New `TestAutoWebP/no_auto_no_vary`: with auto format off, `Accept` is never read, so no `Vary`.

Verified end-to-end on a build of this branch: all four client types above now get `Vary: Accept`, and `filters:format(png)` still doesn't.

Happy to adjust the approach if you'd rather signal this differently (e.g. a dedicated field on the request context instead of reusing the `Imagor-Auto-Format` header).

Thanks for imagor — we're migrating to it from thumbor precisely because AVIF and attention crop work out of the box here.
