### PR TITLE
fix: memory leak in loadAndProcess on error

### DIFF
--- a/processor/vipsprocessor/process.go
+++ b/processor/vipsprocessor/process.go
@@ -506,6 +506,11 @@ func (v *Processor) loadAndProcess(
 		}
 	}
 
+	// caller never receives img on any following error and thus can not close it properly
+	if img != nil {
+		contextDefer(ctx, img.Close)
+	}
+
 	if orient > 0 {
 		// orient rotate before resize
 		if err = img.RotMultiPage(getAngle(orient)); err != nil {

--- a/processor/vipsprocessor/processor_test.go
+++ b/processor/vipsprocessor/processor_test.go
@@ -748,6 +748,29 @@ func TestProcessor(t *testing.T) {
 			http.MethodGet, "/unsafe/dancing-banana.gif", nil))
 		assert.Equal(t, 422, w.Code)
 	})
+	t.Run("no memory leak when filter errors after image has been loaded", func(t *testing.T) {
+		app := imagor.New(
+			imagor.WithLoaders(filestorage.New(testDataDir)),
+			imagor.WithUnsafe(true),
+			imagor.WithDebug(true),
+			imagor.WithLogger(zap.NewExample()),
+			imagor.WithProcessors(NewProcessor(
+				WithDebug(true),
+				WithFilter("error", func(_ context.Context, _ *vips.Image, _ imagor.LoadFunc, _ ...string) error {
+					return imagor.NewError("boom", 422)
+				}),
+			)),
+		)
+		require.NoError(t, app.Startup(context.Background()))
+		t.Cleanup(func() {
+			assert.NoError(t, app.Shutdown(context.Background()))
+		})
+		// memory leaks are caught by the ReportLeaks check
+		w := httptest.NewRecorder()
+		app.ServeHTTP(w, httptest.NewRequest(
+			http.MethodGet, "/unsafe/filters:error()/gopher-front.png", nil))
+		assert.Equal(t, 422, w.Code)
+	})
 	t.Run("image cache — LoadFromCache returns cached blob", func(t *testing.T) {
 		// Verify that LoadFromCache returns the cached blob after Process populates the cache,
 		// and that Process can use it directly (no nil blob, no TOCTOU).


### PR DESCRIPTION
### Bug

When loadAndProcess fails after the image has been loaded (e.g. an orient rotate failure, or any filter returning an error), the loaded image is never closed. The caller only closes on success:

```
  img, err := v.loadAndProcess(ctx, blob, p, load)
  if err != nil {
      return nil, err  // img was created inside loadAndProcess but is unreachable here
  }
  defer img.Close()
```

Today this is barely hit, but it could become an issue if you switch from silent no-op to actual errors (#806).

### Solution

Register image for cleanup via contextDefer so that this specific scenario is guarded against. (Nil guard is only for static analysis)

### Testing

- Added a regression test that triggers a filter error after load; on current master it trips the existing ReportLeaks gate, and passes with the fix.
- All tests pass